### PR TITLE
chore: harden release readiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,61 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  release-preflight:
+    name: Release Preflight
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Set up devenv cache
+        uses: cachix/cachix-action@v16
+        with:
+          name: devenv
+
+      - name: Install devenv
+        shell: bash
+        run: nix profile add nixpkgs#devenv
+
+      - name: Run backend, frontend, CLI, and docs checks
+        shell: devenv shell bash -- -e {0}
+        run: |
+          mkdir -p backend/cmd/openpost/public
+          touch backend/cmd/openpost/public/.gitkeep
+
+          backend-format-check
+          backend-lint
+          cd backend
+          go test -v ./...
+          cd ..
+
+          cd frontend
+          bun install --frozen-lockfile
+          bun run lint
+          bun run check
+          bun run test
+          bun run build
+          cd ..
+
+          cd cli
+          go mod download
+          go build ./...
+          go test ./...
+          cd ..
+
+          cd docs-site
+          bun install --frozen-lockfile
+          bun run docs:build
+
   build-docker:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+    needs: release-preflight
     permissions:
       contents: read
       packages: write
@@ -55,6 +107,7 @@ jobs:
   build-frontend-assets:
     name: Build Frontend Assets
     runs-on: ubuntu-latest
+    needs: release-preflight
 
     steps:
       - name: Checkout repository
@@ -144,6 +197,7 @@ jobs:
   build-cli:
     name: Build CLI Release Binaries
     runs-on: ${{ matrix.runner }}
+    needs: release-preflight
     permissions:
       contents: write
 
@@ -208,6 +262,7 @@ jobs:
   build-android:
     name: Build Android APK
     runs-on: ubuntu-latest
+    needs: release-preflight
     permissions:
       contents: write
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,61 +1,58 @@
 # OpenPost Roadmap
 
-> Status: May 2026 — Prioritized feature list and technical milestones
+> Status: June 2026 — post-v1 priorities.
 
-OpenPost is a lightweight, self-hosted social media scheduler. This roadmap outlines the planned evolution of the project as a linear, prioritized list.
-
----
-
-## ✅ Completed
-
-- **2FA (TOTP)**: Account-level two-factor authentication with time-based one-time passwords.
-- **Passkeys**: WebAuthn-based passwordless login support.
+OpenPost is a lightweight, self-hosted social media scheduler. The core product now includes the web app, CLI, API tokens, social sets, TOTP, passkeys, workspaces, media library, and provider publishing flows. The next phase should focus on reliability, provider correctness, and operator polish before larger integrations.
 
 ---
 
-## 🚀 Upcoming Features
+## Current Focus
 
-1.  **Per-Platform Media Overrides (Frontend)**  
-    Add UI to the "Customize per platform" view in the composer to allow selecting different media attachments for different social accounts. (Backend is already implemented).
+1. **Release hardening**
+   Keep Docker, binary, CLI, Android, and docs release paths reproducible. Release tags should run backend, frontend, CLI, and docs checks before artifacts are published.
 
-2.  **Enhanced Thread Management**  
-    Add backend and frontend support for atomic updates to threads that are already scheduled or have failed, allowing for easier mass-edits of multi-post chains.
+2. **Scheduler reliability**
+   Improve recovery for interrupted jobs, stale processing jobs, retry behavior, and activity-state reporting.
 
-3.  **API Key Management**  
-    Implement a scoped API key system (`api_keys` table + middleware) and a management UI in Settings to allow programmatic access to the OpenPost API.
+3. **Provider verification**
+   Re-test real-account publishing flows for text, images, threads, and video where support is claimed. Keep public docs conservative where provider APIs or review requirements are uncertain.
 
-4.  **Directus Integration**  
-    Enable two-way sync with Directus CMS, allowing published posts and media to be automatically archived or managed within a Directus collection.
-
-5.  **MCP Server**  
-    Implement an official Model Context Protocol (MCP) server for OpenPost. This will allow AI agents (Claude, Cursor, etc.) to interact directly with your instance to list accounts, schedule posts, and upload media.
-
-6.  **AI Writing Assistance (Genkit)**  
-    Integrate Google's Genkit for structured AI workflows, supporting Gemini and OpenAI for tone adjustment, rewrites, and content brainstorming directly in the composer.
-
-7.  **Analytics & Engagement Tracking**  
-    Implement a background worker to periodically poll platform APIs for engagement metrics (likes, reposts, clicks) and display them in a new Analytics dashboard.
-
-8.  **Active Session Management**  
-    Add a security view in Settings to list and revoke active JWT-based login sessions across different devices.
-
-9.  **Full Pagination for List Endpoints**  
-    Update the `Posts` and `Jobs` list endpoints to support full cursor or offset-based pagination (currently only supports simple limits).
-
-10. **Spanish Localization**  
-    Complete the translation files to provide full Spanish language
-    support alongside English and Portuguese. The `es.json` stub was
-    removed in v1.0.x; this item is blocked on a real translator.
+4. **Operator documentation**
+   Keep `.env.example`, Docker, reverse proxy, backup/restore, provider setup, and production checklist docs aligned with runtime behavior.
 
 ---
 
-## 🛠️ Technical Debt & Polish
+## Upcoming Features
 
-11. **Test Coverage Expansion**  
-    Increase backend test coverage to >80% for critical publishing and authentication paths.
+1. **Enhanced thread management**
+   Add safer atomic updates to scheduled or failed threads.
 
-12. **Background Worker Robustness**  
-    Improve error recovery and exponential backoff strategies in the custom SQLite-backed job worker.
+2. **Active session management**
+   Add a settings view to list and revoke active web login sessions.
 
-13. **UI/UX Refinement**  
-    Ongoing polish of the Svelte 5 composer and dashboard interactions to ensure a "native-feeling" experience.
+3. **Full pagination for list endpoints**
+   Add cursor or offset pagination for posts, jobs, and other large lists.
+
+4. **Analytics and engagement tracking**
+   Poll provider APIs for engagement metrics and display them in an analytics dashboard.
+
+5. **MCP server**
+   Add an official automation server for local tools and agents.
+
+6. **Writing assistance**
+   Add optional rewrite and content brainstorming workflows without making OpenPost depend on a hosted provider.
+
+7. **Directus integration**
+   Explore two-way sync with Directus for users who want a separate content archive.
+
+8. **Spanish localization**
+   Complete Spanish translations with a real translation pass. The old stub was removed in v1.0.x.
+
+---
+
+## Technical Debt and Polish
+
+- Expand backend test coverage around publishing, authentication, provider adapters, and queue recovery.
+- Add browser-level smoke tests for first-run setup, workspace creation, draft creation, scheduling, and activity status.
+- Improve mobile and Android app polish after the web flow is stable.
+- Keep the composer fast, readable, and conservative about provider-specific limitations.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,108 +2,74 @@
 
 ## Supported Versions
 
-We release patches for security vulnerabilities. The following versions are currently supported:
+Security patches are currently provided for the latest OpenPost release line.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| latest  | ✅ Yes             |
-| v0.x    | ✅ Security fixes |
+| Version | Supported |
+| ------- | --------- |
+| latest  | Yes       |
+| v1.x    | Yes       |
 
 We recommend always using the latest release for security patches and improvements.
 
 ## Reporting a Vulnerability
 
-We take security vulnerabilities seriously. If you discover a security issue, please report it responsibly.
+Please do not create a public GitHub issue for security vulnerabilities.
 
-### How to Report
+Email the maintainer at `openpost+security@rgo.pt` and include:
 
-1. **Do NOT** create a public GitHub issue for security vulnerabilities
-2. Email the maintainer directly at: `openpost+security@rgo.pt`
-3. Include in your report:
-   - Description of the vulnerability
-   - Steps to reproduce the issue
-   - Potential impact
-   - Any suggested fixes (optional)
-
-### What to Expect
-
-- **Acknowledgment:** We will acknowledge your report within 48 hours
-- **Status Update:** We will provide regular updates on the progress of addressing the vulnerability
-- **Disclosure:** We will publicly disclose the vulnerability after a fix is available
-- **Credit:** We will credit reporters in the security advisory (unless you prefer to remain anonymous)
-
-### Response Timeline
-
-- **Initial response:** Within 48 hours
-- **Severity assessment:** Within 7 days
-- **Fix development:** Varies by complexity (typically 1-4 weeks)
-- **Public disclosure:** After patch is available
+- Description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact
+- Any suggested fixes, if available
 
 ## Security Best Practices for Self-Hosters
 
-When running OpenPost, follow these security practices:
-
 ### Secrets Management
 
-- **Never commit `.env`** files to version control
-- Use strong, randomly generated secrets (`openssl rand -base64 32`)
-- Rotate secrets periodically
-- Use Docker secrets, Kubernetes secrets, or a secrets manager in production
-- Restrict access to `OPENPOST_ENCRYPTION_KEY`: encrypted provider tokens still depend on that key to be decrypted
-- Limit read access to the OpenPost runtime user for `.env`, backup archives, and service configuration files
+- Never commit `.env` files to version control.
+- Use strong, randomly generated secrets, for example `openssl rand -base64 32`.
+- Rotate secrets periodically.
+- Use Docker secrets, Kubernetes secrets, or a secrets manager in production where possible.
+- Restrict access to `OPENPOST_ENCRYPTION_KEY`, `.env`, backup archives, and service configuration files.
 
 ### Network Security
 
-- Run behind a reverse proxy with TLS/HTTPS
-- Configure a proper firewall
-- Don't expose the OpenPost port directly to the internet (except for OAuth callbacks)
-- For Threads: ensure `/media/` endpoint is publicly accessible for media uploads
-- Use HTTPS before configuring production OAuth callbacks for X, Mastodon, LinkedIn, or Threads
+- Run behind a reverse proxy with TLS.
+- Configure a proper firewall.
+- Do not expose the OpenPost port directly to the internet unless that is part of your deliberate reverse-proxy setup.
+- For Threads media publishing, make sure the public media endpoint is reachable by Meta.
+- Use HTTPS before configuring production OAuth callbacks for X, Mastodon, LinkedIn, or Threads.
 
 ### Data Protection
 
-- Back up your database and media directory regularly
-- Back up your `.env` or secret-management configuration together with the database and media directory
-- Store backups in a secure location
-- Consider encrypting backups at rest
-- Restrict filesystem permissions on the SQLite database, media folder, and backup artifacts
+- Back up the database and media directory regularly.
+- Back up secrets together with the database and media directory.
+- Store backups in a secure location.
+- Consider encrypting backups at rest.
+- Restrict filesystem permissions on the SQLite database, media folder, and backup artifacts.
 
 ### OAuth Provider Security
 
-- Regularly review connected accounts
-- Rotate OAuth tokens and secrets periodically
-- Revoke access for accounts no longer in use
+- Regularly review connected accounts.
+- Rotate OAuth tokens and secrets periodically.
+- Revoke access for accounts no longer in use.
 
 ## Security Features in OpenPost
 
-OpenPost includes the following security measures:
+OpenPost includes:
 
-- **Token encryption:** All OAuth tokens are encrypted at rest using AES-256-GCM
-- **Password hashing:** User passwords are hashed with bcrypt
-- **JWT authentication:** Secure token-based session management
-- **Account MFA:** TOTP enrollment and verification for user accounts
-- **Passkeys:** WebAuthn passkey registration and login support
-- **OAuth PKCE:** Twitter authentication uses PKCE for improved security
-- **No external dependencies:** Self-contained binary with no external service dependencies
+- Encrypted OAuth tokens at rest
+- Bcrypt password hashing
+- JWT authentication
+- Account MFA with TOTP
+- WebAuthn passkeys
+- OAuth PKCE for X authentication
+- A self-contained server binary with no required external queue or database service
 
 ## Third-Party Dependencies
 
-We regularly update dependencies to address security vulnerabilities. We use:
-
-- Go dependencies (via Go modules)
-- Frontend dependencies (via Bun/npm)
-- Docker base images from trusted sources
+OpenPost uses Go modules, Bun/npm frontend dependencies, and Docker base images. Keep deployments updated to receive dependency fixes.
 
 ## Scope
 
-This security policy applies to:
-
-- The OpenPost server application
-- The embedded SvelteKit frontend
-- OAuth integration with supported platforms
-
-This does not apply to:
-
-- Third-party OAuth providers (Twitter, Mastodon, Bluesky, LinkedIn, Threads)
-- Your deployment infrastructure (reverse proxy, firewall, etc.)
-- External databases or storage systems you configure
+This policy applies to the OpenPost server, embedded frontend, and OAuth integrations. It does not cover third-party OAuth providers, deployment infrastructure, or external storage services you configure.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,124 +1,64 @@
 # OpenPost Configuration
+# =============================================================================
+# This backend-local example is intentionally safe to copy.
+# The canonical deployment example lives at ../.env.example.
+#
+# Set OPENPOST_APP_URL before the first real deployment. OAuth callback URLs,
+# WebAuthn relying-party IDs, CORS, and public media URLs are derived from it.
+# =============================================================================
 
 # =============================================================================
 # Server Configuration
 # =============================================================================
-
 OPENPOST_PORT=8080
-
-# Database path - in production with Docker, use /data/db/openpost.db
 OPENPOST_DATABASE_PATH=file:openpost.db?cache=shared&mode=rwc
-
-# Frontend URL for CORS - update for production
-OPENPOST_APP_URL=http://localhost:8080
-
-# Additional CORS origins (comma-separated) - useful for reverse proxies
-# Example: https://openpost.yourdomain.com,https://another.domain.com
-OPENPOST_EXTRA_CORS_ORIGINS=
-
-# Disable self-service signups after initial setup. The first account is always
-# allowed so a fresh instance can still be bootstrapped.
-OPENPOST_DISABLE_REGISTRATIONS=false
-
-# Authentication Secrets (GENERATE NEW ONES FOR PRODUCTION)
-# Generate with: openssl rand -base64 32
-OPENPOST_JWT_SECRET=generate_a_secure_random_string_here
-OPENPOST_ENCRYPTION_KEY=generate_a_secure_random_string_here
-
-# =============================================================================
-# Media Upload Configuration
-# =============================================================================
-
-# Local storage path for uploaded media files
 OPENPOST_MEDIA_PATH=./media
+OPENPOST_MEDIA_URL=/media
+OPENPOST_APP_URL=http://localhost:8080
+OPENPOST_PUBLIC_URL=http://localhost:8080
+OPENPOST_EXTRA_CORS_ORIGINS=
+OPENPOST_DISABLE_REGISTRATIONS=false
+TZ=UTC
 
-# Full media URL for production (required for Threads, useful for other platforms)
-# Format: https://your-domain.com/media
-OPENPOST_MEDIA_URL=http://localhost:8080/media
+# =============================================================================
+# Authentication Secrets (GENERATE NEW ONES FOR PRODUCTION)
+# =============================================================================
+# Generate with: openssl rand -base64 32
+OPENPOST_JWT_SECRET=change-this-jwt-secret-min-32-chars
+OPENPOST_ENCRYPTION_KEY=change-this-encryption-key-32ch
 
 # =============================================================================
 # Platform OAuth Credentials
 # =============================================================================
 # Configure only the platforms you need. Leave empty to disable a platform.
+# Each *_REDIRECT_URI below is optional. If left blank, OpenPost derives the
+# correct callback URL from OPENPOST_APP_URL. Mastodon uses OOB by default.
 
-# -----------------------------------------------------------------------------
-# Twitter/X OAuth 1.0a
-# Get credentials from: https://developer.twitter.com/en/portal/dashboard
-# Callback URL: http://localhost:8080/api/v1/accounts/x/callback
-# App type: OAuth 1.0a user context
-# Media limits: 4 images (5MB each) OR 1 video (512MB)
-# -----------------------------------------------------------------------------
-X_CLIENT_ID=your_twitter_client_id_here
-X_CLIENT_SECRET=your_twitter_client_secret_here
-# Optional override for production or non-default callback routing
-X_REDIRECT_URI=http://localhost:8080/api/v1/accounts/x/callback
+# X / Twitter
+# Default redirect: ${OPENPOST_APP_URL}/api/v1/accounts/x/callback
+X_CLIENT_ID=
+X_CLIENT_SECRET=
+X_REDIRECT_URI=
 
-# -----------------------------------------------------------------------------
-# Mastodon OAuth (supports multiple instances)
-# Create an app on each instance: Settings > Development > New Application
-# Callback URL: http://localhost:8080/api/v1/accounts/mastodon/callback
-# Required scopes: read, write
-# Media limits: 4 attachments (images 10MB, video 40MB)
-# -----------------------------------------------------------------------------
-MASTODON_REDIRECT_URI=http://localhost:8080/api/v1/accounts/mastodon/callback
-# For production, use: https://your-domain.com/api/v1/accounts/mastodon/callback
-MASTODON_SERVERS='[
-  {"name":"Personal","client_id":"your_client_id","client_secret":"your_client_secret","instance_url":"https://mastodon.social"}
-]'
-# Multiple servers example:
-# MASTODON_SERVERS='[
-#   {"name":"Personal","client_id":"abc","client_secret":"xyz","instance_url":"https://mastodon.social"},
-#   {"name":"Work","client_id":"def","client_secret":"uvw","instance_url":"https://fosstodon.org"}
-# ]'
+# Mastodon
+# MASTODON_REDIRECT_URI defaults to the OOB URI and usually does not need a
+# public callback URL.
+MASTODON_REDIRECT_URI=urn:ietf:wg:oauth:2.0:oob
+MASTODON_SERVERS=[]
 
-# -----------------------------------------------------------------------------
-# Bluesky (App Passwords)
-# No setup needed - just use your handle and app password from Bluesky settings.
-# Settings > App Passwords > Create App Password
-# Media limits: 4 images (1MB each) OR 1 video (50MB)
-# -----------------------------------------------------------------------------
+# Bluesky
+# No server-side credentials required. Users connect with handle + app password.
 
-# -----------------------------------------------------------------------------
-# LinkedIn OAuth
-# Get credentials from: https://www.linkedin.com/developers/apps
-# Callback URL: http://localhost:8080/api/v1/accounts/linkedin/callback
-# Required scopes: openid, profile, w_member_social, w_member_social_feed
-# IMPORTANT: LinkedIn must approve your app for Social Actions (comments/replies).
-# Without this permission, threaded replies on LinkedIn will fail with ACCESS_DENIED.
-# Set to true to disable LinkedIn replies for thread child posts (recommended if
-# your app cannot obtain w_member_social_feed approval yet).
+# LinkedIn
+# Default redirect: ${OPENPOST_APP_URL}/api/v1/accounts/linkedin/callback
+LINKEDIN_CLIENT_ID=
+LINKEDIN_CLIENT_SECRET=
+LINKEDIN_REDIRECT_URI=
 LINKEDIN_DISABLE_THREAD_REPLIES=false
-# Media limits: 1 image OR 1 video (preview may show one attachment only)
-# Threading: Posts as comments on the first post (not native threads)
-# -----------------------------------------------------------------------------
-LINKEDIN_CLIENT_ID=your_linkedin_client_id_here
-LINKEDIN_CLIENT_SECRET=your_linkedin_client_secret_here
-LINKEDIN_REDIRECT_URI=http://localhost:8080/api/v1/accounts/linkedin/callback
 
-# -----------------------------------------------------------------------------
-# Threads OAuth (Meta Graph API)
-# Get credentials from: https://developers.facebook.com/
-# Create a Business app and add Threads API product
-# Required scopes: threads_basic, threads_content_publish, threads_manage_replies
-# Media limits: 1 image OR 1 video
-# IMPORTANT: Threads requires publicly accessible URLs for media.
-# For local development, use ngrok to expose your media endpoint:
-#   1. Run: ngrok http 8080
-#   2. Use the https URL for THREADS_REDIRECT_URI
-#   3. The /media/{id} endpoint must be publicly reachable for media uploads
-# -----------------------------------------------------------------------------
-THREADS_CLIENT_ID=your_meta_app_id_here
-THREADS_CLIENT_SECRET=your_meta_app_secret_here
-THREADS_REDIRECT_URI=http://localhost:8080/api/v1/accounts/threads/callback
-
-# =============================================================================
-# Production Checklist
-# =============================================================================
-# When deploying in production:
-# 1. Generate new secrets: openssl rand -base64 32
-# 2. Set OPENPOST_APP_URL to your production domain
-# 3. Set OPENPOST_MEDIA_URL to your production media URL (https://...)
-# 4. Update CORS settings with your production domain
-# 5. Configure reverse proxy with TLS (Caddy, Nginx, Traefik, etc.)
-# 6. Update OAuth callback URLs to use https://
-# 7. For Threads: ensure your /media endpoint is publicly accessible
+# Threads / Meta
+# Default redirect: ${OPENPOST_APP_URL}/api/v1/accounts/threads/callback
+# Threads requires HTTPS redirects and a public OPENPOST_MEDIA_URL for media.
+THREADS_CLIENT_ID=
+THREADS_CLIENT_SECRET=
+THREADS_REDIRECT_URI=

--- a/backend/internal/queue/worker.go
+++ b/backend/internal/queue/worker.go
@@ -16,13 +16,14 @@ import (
 )
 
 const (
-	jobTypePublishPost  = "publish_post"
-	jobStatusPending    = "pending"
-	jobTypeMediaCleanup = "media_cleanup"
-	jobTypeRefreshToken = "refresh_token"
-	jobStatusProcessing = "processing"
-	jobStatusFailed     = "failed"
-	jobStatusCompleted  = "completed"
+	jobTypePublishPost    = "publish_post"
+	jobStatusPending      = "pending"
+	jobTypeMediaCleanup   = "media_cleanup"
+	jobTypeRefreshToken   = "refresh_token"
+	jobStatusProcessing   = "processing"
+	jobStatusFailed       = "failed"
+	jobStatusCompleted    = "completed"
+	staleProcessingJobAge = "-15 minutes"
 )
 
 // BackgroundWorker polls the SQLite database for pending jobs.
@@ -73,10 +74,29 @@ func (w *BackgroundWorker) Stop() {
 }
 
 func (w *BackgroundWorker) processDueJobs(ctx context.Context) {
+	w.requeueStaleProcessingJobs(ctx)
 	for {
 		if !w.processNextJobIfAvailable(ctx) {
 			return
 		}
+	}
+}
+
+func (w *BackgroundWorker) requeueStaleProcessingJobs(ctx context.Context) {
+	result, err := w.db.NewRaw(`
+		UPDATE jobs
+		SET status = ?, locked_at = NULL, locked_by = ''
+		WHERE status = ?
+			AND locked_at IS NOT NULL
+			AND locked_at <= datetime('now', ?)
+	`, jobStatusPending, jobStatusProcessing, staleProcessingJobAge).Exec(ctx)
+	if err != nil {
+		log.Printf("[Worker %s] failed to requeue stale processing jobs: %v\n", w.workerID, err)
+		return
+	}
+	rows, err := result.RowsAffected()
+	if err == nil && rows > 0 {
+		log.Printf("[Worker %s] requeued %d stale processing job(s)\n", w.workerID, rows)
 	}
 }
 

--- a/backend/internal/queue/worker_recovery_test.go
+++ b/backend/internal/queue/worker_recovery_test.go
@@ -1,0 +1,74 @@
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/openpost/backend/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkerRequeuesStaleProcessingJobs(t *testing.T) {
+	t.Parallel()
+
+	db := createTestDB(t)
+	ctx := context.Background()
+	jobID := uuid.NewString()
+	job := &models.Job{
+		ID:          jobID,
+		Type:        jobTypePublishPost,
+		Payload:     "{}",
+		Status:      jobStatusProcessing,
+		RunAt:       time.Now().UTC().Add(-time.Hour),
+		Attempts:    0,
+		MaxAttempts: 3,
+		LockedAt:    time.Now().UTC().Add(-20 * time.Minute),
+		LockedBy:    "dead-worker",
+	}
+	_, err := db.NewInsert().Model(job).Exec(ctx)
+	require.NoError(t, err)
+
+	worker := &BackgroundWorker{db: db, workerID: "worker-test"}
+	worker.requeueStaleProcessingJobs(ctx)
+
+	stored := new(models.Job)
+	err = db.NewSelect().Model(stored).Where("id = ?", jobID).Scan(ctx)
+	require.NoError(t, err)
+	require.Equal(t, jobStatusPending, stored.Status)
+	require.True(t, stored.LockedAt.IsZero())
+	require.Empty(t, stored.LockedBy)
+}
+
+func TestWorkerKeepsRecentProcessingJobsLocked(t *testing.T) {
+	t.Parallel()
+
+	db := createTestDB(t)
+	ctx := context.Background()
+	jobID := uuid.NewString()
+	lockedAt := time.Now().UTC().Add(-5 * time.Minute)
+	job := &models.Job{
+		ID:          jobID,
+		Type:        jobTypePublishPost,
+		Payload:     "{}",
+		Status:      jobStatusProcessing,
+		RunAt:       time.Now().UTC().Add(-time.Hour),
+		Attempts:    0,
+		MaxAttempts: 3,
+		LockedAt:    lockedAt,
+		LockedBy:    "active-worker",
+	}
+	_, err := db.NewInsert().Model(job).Exec(ctx)
+	require.NoError(t, err)
+
+	worker := &BackgroundWorker{db: db, workerID: "worker-test"}
+	worker.requeueStaleProcessingJobs(ctx)
+
+	stored := new(models.Job)
+	err = db.NewSelect().Model(stored).Where("id = ?", jobID).Scan(ctx)
+	require.NoError(t, err)
+	require.Equal(t, jobStatusProcessing, stored.Status)
+	require.False(t, stored.LockedAt.IsZero())
+	require.Equal(t, "active-worker", stored.LockedBy)
+}

--- a/docs-site/configuration/environment-variables.md
+++ b/docs-site/configuration/environment-variables.md
@@ -1,6 +1,6 @@
 # Environment Variables
 
-This page summarizes the env vars used by the backend. Some values in `backend/.env.example` are recommended deployment examples; code defaults may differ.
+This page summarizes the env vars used by the backend. Some values in `.env.example` are recommended deployment examples; code defaults may differ.
 
 ## Core settings
 
@@ -22,38 +22,38 @@ This page summarizes the env vars used by the backend. Some values in `backend/.
 
 | Variable | Required | Default | Description |
 |---|---:|---|---|
-| `X_CLIENT_ID` | Yes for X | empty | X OAuth client ID. |
+| `X_CLIENT_ID` | Yes for X | empty | X OAuth client ID. Leave empty to disable X. |
 | `X_CLIENT_SECRET` | Yes for X | empty | X OAuth client secret. |
-| `X_REDIRECT_URI` | No | `http://localhost:8080/api/v1/accounts/x/callback` | X OAuth 1.0a callback URL override. |
+| `X_REDIRECT_URI` | No | derived from `OPENPOST_APP_URL` | X OAuth callback URL override. |
 
 ## Mastodon
 
 | Variable | Required | Default | Description |
 |---|---:|---|---|
-| `MASTODON_REDIRECT_URI` | No | `http://localhost:8080/api/v1/accounts/mastodon/callback` | Mastodon callback URL override. |
-| `MASTODON_SERVERS` | Yes for Mastodon | empty | JSON array of configured Mastodon apps and instance URLs. |
+| `MASTODON_REDIRECT_URI` | No | `urn:ietf:wg:oauth:2.0:oob` | Mastodon redirect URI. The default uses the OOB flow and does not need a public callback URL. |
+| `MASTODON_SERVERS` | Yes for Mastodon | `[]` | JSON array of configured Mastodon apps and instance URLs. Leave empty to disable Mastodon. |
 
 ## LinkedIn
 
 | Variable | Required | Default | Description |
 |---|---:|---|---|
-| `LINKEDIN_CLIENT_ID` | Yes for LinkedIn | empty | LinkedIn OAuth client ID. |
+| `LINKEDIN_CLIENT_ID` | Yes for LinkedIn | empty | LinkedIn OAuth client ID. Leave empty to disable LinkedIn. |
 | `LINKEDIN_CLIENT_SECRET` | Yes for LinkedIn | empty | LinkedIn OAuth client secret. |
-| `LINKEDIN_REDIRECT_URI` | No | `http://localhost:8080/api/v1/accounts/linkedin/callback` | LinkedIn callback URL override. |
+| `LINKEDIN_REDIRECT_URI` | No | derived from `OPENPOST_APP_URL` | LinkedIn callback URL override. |
 | `LINKEDIN_DISABLE_THREAD_REPLIES` | No | `false` | Disable LinkedIn comment-style child replies for thread posts. |
 
 ## Threads
 
 | Variable | Required | Default | Description |
 |---|---:|---|---|
-| `THREADS_CLIENT_ID` | Yes for Threads | empty | Meta app ID. |
+| `THREADS_CLIENT_ID` | Yes for Threads | empty | Meta app ID. Leave empty to disable Threads. |
 | `THREADS_CLIENT_SECRET` | Yes for Threads | empty | Meta app secret. |
-| `THREADS_REDIRECT_URI` | No | `http://localhost:8080/api/v1/accounts/threads/callback` | Threads callback URL override. |
+| `THREADS_REDIRECT_URI` | No | derived from `OPENPOST_APP_URL` | Threads callback URL override. Threads production redirects must use HTTPS. |
 
 ## Notes
 
 - The preferred names above are what new deployments should use.
 - Backward-compatible aliases still work for existing installs: `OPENPOST_DB_PATH`, `OPENPOST_FRONTEND_URL`, `OPENPOST_CORS_EXTRA_ORIGINS`, `JWT_SECRET`, `ENCRYPTION_KEY`, `TWITTER_CLIENT_ID`, `TWITTER_CLIENT_SECRET`, `TWITTER_REDIRECT_URI`, and `OPENPOST_DISABLE_LINKEDIN_THREAD_REPLIES`.
-- `backend/.env.example` is still the best copy-paste starting point.
+- The root `.env.example` is the best copy-paste starting point.
 - Set explicit public URLs in production even when defaults exist.
 - For Threads, treat `OPENPOST_MEDIA_URL` as mandatory.

--- a/docs-site/configuration/production-checklist.md
+++ b/docs-site/configuration/production-checklist.md
@@ -1,13 +1,17 @@
 # Production Checklist
 
+- [ ] Copy the root `.env.example` to `.env` and remove placeholder values
 - [ ] Generate fresh `OPENPOST_JWT_SECRET`
 - [ ] Generate fresh `OPENPOST_ENCRYPTION_KEY`
 - [ ] Use secrets that are at least 32 characters long
-- [ ] Set `OPENPOST_APP_URL`
-- [ ] Set `OPENPOST_MEDIA_URL`
+- [ ] Set `OPENPOST_APP_URL` to the public HTTPS app origin
+- [ ] Set `OPENPOST_PUBLIC_URL` to the public HTTPS app origin
+- [ ] Set `OPENPOST_MEDIA_URL` to the public HTTPS media base URL
 - [ ] Decide whether to set `OPENPOST_DISABLE_REGISTRATIONS=true` after creating the first admin account
 - [ ] Configure reverse proxy with HTTPS
-- [ ] Update provider callback URLs
+- [ ] Update provider callback URLs for X, LinkedIn, and Threads
+- [ ] Configure Mastodon servers in `MASTODON_SERVERS` if you need Mastodon
 - [ ] Persist `/data`
-- [ ] Back up database and media
+- [ ] Back up database, media, and secrets together
 - [ ] Check `GET /api/v1/health`
+- [ ] Create a test draft and scheduled post before relying on automation

--- a/docs-site/guide/quickstart.md
+++ b/docs-site/guide/quickstart.md
@@ -22,7 +22,6 @@ services:
       - OPENPOST_PORT=8080
       - OPENPOST_DATABASE_PATH=/data/db/openpost.db
       - OPENPOST_MEDIA_PATH=/data/media
-      - OPENPOST_MEDIA_URL=http://localhost:8080/media
 
 volumes:
   openpost_data:
@@ -30,21 +29,15 @@ volumes:
 
 ## 2. Create `.env`
 
-Create a `.env` file next to `docker-compose.yml`:
+From the repository root, copy the safe deployment example:
 
-```dotenv
-OPENPOST_PORT=8080
-OPENPOST_DATABASE_PATH=/data/db/openpost.db
-OPENPOST_MEDIA_PATH=/data/media
-OPENPOST_MEDIA_URL=http://localhost:8080/media
-
-OPENPOST_JWT_SECRET=replace-with-a-random-secret-at-least-32-characters-long
-OPENPOST_ENCRYPTION_KEY=replace-with-a-random-secret-at-least-32-characters-long
-
-# Start with Bluesky if you want the easiest first provider:
-# no server-side OAuth app is required.
-# Add other provider env vars later as needed.
+```bash
+cp .env.example .env
 ```
+
+Set fresh values for the two required secrets, then set `OPENPOST_APP_URL`, `OPENPOST_PUBLIC_URL`, and `OPENPOST_MEDIA_URL` for the URL where users will actually reach the app. For a local trial, `http://localhost:8080` is fine.
+
+Start with Bluesky if you want the easiest first provider: no server-side OAuth app is required. Add other provider env vars later as needed.
 
 ## 3. Generate secrets
 
@@ -53,7 +46,7 @@ openssl rand -base64 32
 openssl rand -base64 32
 ```
 
-Set the generated values as `OPENPOST_JWT_SECRET` and `OPENPOST_ENCRYPTION_KEY`.
+Use one generated value for the JWT secret and the other for the encryption key.
 
 ::: warning
 Do not use placeholder secrets in production.
@@ -96,7 +89,7 @@ Start with **Bluesky** if you want the fastest validation path:
 
 ## HTTPS note
 
-`http://localhost:8080` is fine for a local trial. Before configuring production OAuth callbacks, put OpenPost behind HTTPS with a real domain. That matters for X, Mastodon, LinkedIn, and Threads callback validation, and for Threads public media fetches.
+`http://localhost:8080` is fine for a local trial. Before configuring production OAuth callbacks, put OpenPost behind HTTPS with a real domain and update `OPENPOST_APP_URL`, `OPENPOST_PUBLIC_URL`, and `OPENPOST_MEDIA_URL`. That matters for X, LinkedIn, Threads callback validation, WebAuthn/passkeys, and Threads public media fetches.
 
 If you want to close self-service signups after setup, set `OPENPOST_DISABLE_REGISTRATIONS=true` and restart OpenPost. The first account is still allowed on a brand-new instance even when that flag is enabled.
 

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -17,36 +17,20 @@ hero:
       link: https://github.com/rodrgds/openpost
 
 features:
-  - icon: ✍️
-    title: Typefully-like composer
-    details: Write once, customize per platform. Tailor copy for each connected account when needed.
-  - icon: 🧵
-    title: Thread composer
-    details: Build multi-post threads and publish them in sequence instead of stitching replies together manually.
-  - icon: 📅
-    title: Scheduling that stays queued
-    details: Plan posts ahead, use posting schedules, and keep jobs durable through restarts.
-  - icon: 🖼️
-    title: Reusable media library
-    details: Upload once, reuse across drafts and scheduled posts, and keep media close to your content workflow.
-  - icon: 🗂️
-    title: Workspaces for separate brands
-    details: Keep accounts, media, prompts, and schedules organized per workspace.
-  - icon: 🌐
-    title: One post, many networks
-    details: Publish from one place to X, Mastodon, Bluesky, Threads, and LinkedIn.
-  - icon: 🔐
-    title: Your server, your credentials
-    details: Keep content, schedules, and connected account tokens under your own control.
-  - icon: ⚡
-    title: Fast to deploy
-    details: Run OpenPost with Docker Compose or a single binary without turning setup into a platform project.
-  - icon: 🧰
-    title: CLI for automation
-    details: Create posts, upload media, use social sets, and schedule into the next available slot from scripts or CI.
-  - icon: 📱
-    title: Android app
-    details: Install the release APK and use the same self-hosted OpenPost instance from your phone.
+  - title: Composer
+    details: Write once, customize per platform, and preview posts before scheduling.
+  - title: Threads
+    details: Build multi-post threads and publish them in sequence.
+  - title: Scheduling
+    details: Plan posts ahead with durable jobs that survive restarts.
+  - title: Media library
+    details: Upload once and reuse media across drafts and scheduled posts.
+  - title: Workspaces
+    details: Keep separate brands, accounts, media, prompts, and schedules organized.
+  - title: CLI
+    details: Create posts, upload media, use social sets, and automate workflows from scripts or CI.
+  - title: Android app
+    details: Install the release APK and connect it to your self-hosted instance.
 ---
 
 <p>
@@ -56,45 +40,6 @@ features:
     style="width: 100%; max-width: 1200px; border-radius: 16px; border: 1px solid var(--vp-c-divider);"
   >
 </p>
-
-<div style="margin-top: 24px;">
-  <!-- TODO: update this demo URL! -->
-  <iframe
-    width="100%"
-    max-width="1200px"
-    height="500"
-    src="https://www.youtube.com/embed/dqTTojTija8"
-    title="OpenPost Demo"
-    frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
-    style="border-radius: 16px; border: 1px solid var(--vp-c-divider);"
-  ></iframe>
-</div>
-
-<div
-  style="display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 16px; align-items: start;"
->
-  <div>
-    <img
-      src="/assets/screenshots/settings-dark.png"
-      alt="OpenPost settings page"
-      style="width: 100%; border-radius: 16px; border: 1px solid var(--vp-c-divider);"
-    >
-  </div>
-  <div style="display: grid; gap: 16px;">
-    <img
-      src="/assets/screenshots/accounts-dark.png"
-      alt="OpenPost accounts page"
-      style="width: 100%; border-radius: 16px; border: 1px solid var(--vp-c-divider);"
-    >
-    <img
-      src="/assets/screenshots/media-dark.png"
-      alt="OpenPost media page"
-      style="width: 100%; border-radius: 16px; border: 1px solid var(--vp-c-divider);"
-    >
-  </div>
-</div>
 
 ## Install in a minute
 

--- a/docs-site/installation/docker-compose.md
+++ b/docs-site/installation/docker-compose.md
@@ -26,7 +26,6 @@ services:
       - OPENPOST_PORT=8080
       - OPENPOST_DATABASE_PATH=/data/db/openpost.db
       - OPENPOST_MEDIA_PATH=/data/media
-      - OPENPOST_MEDIA_URL=http://localhost:8080/media
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/api/v1/health"]
       interval: 30s
@@ -40,15 +39,22 @@ volumes:
 
 ## Create `.env`
 
+From the repository root:
+
 ```bash
-cp backend/.env.example .env
+cp .env.example .env
 ```
 
-Set at least:
+If you only copied the Compose file, create `.env` manually and set at least:
 
 - `OPENPOST_JWT_SECRET`
 - `OPENPOST_ENCRYPTION_KEY`
+- `OPENPOST_APP_URL`
+- `OPENPOST_PUBLIC_URL`
+- `OPENPOST_MEDIA_URL`
 - Provider credentials for the networks you want to enable
+
+For local testing, `http://localhost:8080` is fine for the public URL values. In production, use your real HTTPS origin.
 
 ## Generate secrets
 
@@ -98,7 +104,7 @@ docker compose logs -f openpost
 ## Production warnings
 
 - Put OpenPost behind HTTPS before enabling OAuth in production.
-- Set `OPENPOST_APP_URL` and `OPENPOST_MEDIA_URL` to public URLs.
+- Set `OPENPOST_APP_URL`, `OPENPOST_PUBLIC_URL`, and `OPENPOST_MEDIA_URL` to public URLs.
 - Back up both the SQLite database and media directory.
 
 ## Next steps

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "1.0.5",
+	"version": "1.0.16",
 	"type": "module",
 	"scripts": {
 		"sync:assets": "node ../scripts/sync-assets.mjs",


### PR DESCRIPTION
## Summary

- Makes `backend/.env.example` safe to copy by removing fake non-empty provider credentials and aligning it with the root env example.
- Updates Quickstart, Docker Compose, environment-variable, and production-checklist docs around public URLs, provider callbacks, persistence, backups, and scheduled-post smoke testing.
- Corrects the Mastodon env reference to document the runtime OOB default.
- Simplifies the docs homepage and removes the stale launch-demo TODO.
- Refreshes `ROADMAP.md` for the post-v1 state of the product.
- Updates `SECURITY.md` supported versions from stale `v0.x` wording to the current `v1.x` line.
- Aligns `frontend/package.json` with the current release line.
- Adds a release preflight job before release artifacts are built or published.
- Requeues stale `processing` jobs in the SQLite worker before polling due jobs.
- Adds regression tests for stale/recent processing-job recovery.

## Issue follow-up

- Added a resolution comment to issue #2 after checking the current list-posts ordering code path and changelog. The connector blocked closing the issue directly.

## Verification

- Local tests were not run here because the repo is not mounted in this environment and direct GitHub cloning is unavailable.
- GitHub CI has started for this PR head and should be treated as the source of truth before merging.