### PR TITLE
fix: preserve Meta OAuth callback redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
 ### Fixed
 
 - Made remote MCP `GET /mcp` return HTTP 405 instead of falling through to SPA HTML, restoring Streamable HTTP compatibility with clients such as Hermes.
+- Preserved finalized `Location` headers on Meta OAuth callback redirects by setting redirect targets before Huma commits the 307 status.
 - Registered persisted and newly added dynamic Mastodon instance adapters with publishing and token refresh so custom instances can publish without manual server restarts.
 
 ## [1.0.40] - 2026-07-06

--- a/backend/internal/api/handlers/oauth.go
+++ b/backend/internal/api/handlers/oauth.go
@@ -720,8 +720,8 @@ func (h *OAuthHandler) redirectWithError(msg string) (*huma.StreamResponse, erro
 	location := h.frontendURL + "/accounts?error=" + url.QueryEscape(msg)
 	return &huma.StreamResponse{
 		Body: func(ctx huma.Context) {
-			ctx.SetStatus(http.StatusTemporaryRedirect)
 			ctx.SetHeader("Location", location)
+			ctx.SetStatus(http.StatusTemporaryRedirect)
 		},
 	}, nil
 }
@@ -730,8 +730,8 @@ func (h *OAuthHandler) redirectWithAccountSelection(platformName, connectionID s
 	location := h.frontendURL + "/accounts/callback?status=selection_required&platform=" + url.QueryEscape(platformName) + "&connection_id=" + url.QueryEscape(connectionID)
 	return &huma.StreamResponse{
 		Body: func(ctx huma.Context) {
-			ctx.SetStatus(http.StatusTemporaryRedirect)
 			ctx.SetHeader("Location", location)
+			ctx.SetStatus(http.StatusTemporaryRedirect)
 		},
 	}, nil
 }

--- a/backend/internal/api/handlers/oauth_callback_redirect_test.go
+++ b/backend/internal/api/handlers/oauth_callback_redirect_test.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humaecho"
+	"github.com/labstack/echo/v4"
+	"github.com/openpost/backend/internal/models"
+	"github.com/openpost/backend/internal/platform"
+	"github.com/openpost/backend/internal/services/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOAuthCallbackAccountSelectionRedirectsExposeFinalLocationHeader(t *testing.T) {
+	t.Parallel()
+
+	for _, providerName := range []string{"facebook", "instagram"} {
+		t.Run(providerName, func(t *testing.T) {
+			t.Parallel()
+
+			e, state := newOAuthCallbackRedirectTestServer(t, providerName, &selectionTestAdapter{}, "https://app.openpost.test")
+
+			rec := oauthSelectionRequest(t, e, http.MethodGet, "/api/v1/accounts/"+providerName+"/callback?code=provider-code&state="+url.QueryEscape(state), nil, false)
+			result := rec.Result()
+			t.Cleanup(func() { _ = result.Body.Close() })
+
+			require.Equal(t, http.StatusTemporaryRedirect, result.StatusCode)
+			location := result.Header.Get("Location")
+			require.NotEmpty(t, location)
+			require.Contains(t, location, "https://app.openpost.test/accounts/callback")
+			require.Contains(t, location, "status=selection_required")
+			require.Contains(t, location, "platform="+providerName)
+		})
+	}
+}
+
+func TestOAuthCallbackErrorRedirectExposesFinalLocationHeader(t *testing.T) {
+	t.Parallel()
+
+	db := createHandlerTestDB(t)
+	e := echo.New()
+	api := humaecho.NewWithGroup(e, e.Group("/api/v1"), huma.DefaultConfig("Test", "1.0.0"))
+	handler := NewOAuthHandler(db, crypto.NewTokenEncryptor("0123456789abcdef0123456789abcdef"), nil, testAuthenticator{}, false, "https://app.openpost.test")
+	handler.Callback(api)
+
+	rec := oauthSelectionRequest(t, e, http.MethodGet, "/api/v1/accounts/threads/callback?error=access_denied&error_description=Nope", nil, false)
+	result := rec.Result()
+	t.Cleanup(func() { _ = result.Body.Close() })
+
+	require.Equal(t, http.StatusTemporaryRedirect, result.StatusCode)
+	require.Equal(t, "https://app.openpost.test/accounts?error=access_denied%3A+Nope", result.Header.Get("Location"))
+}
+
+func newOAuthCallbackRedirectTestServer(t *testing.T, providerName string, adapter platform.Adapter, frontendURL string) (*echo.Echo, string) {
+	t.Helper()
+
+	ctx := context.Background()
+	db := createHandlerTestDB(t,
+		(*models.WorkspaceMember)(nil),
+		(*models.AuthChallenge)(nil),
+		(*models.OAuthAccountSelection)(nil),
+		(*models.SocialAccount)(nil),
+		(*models.Job)(nil),
+	)
+	_, err := db.NewInsert().Model(&models.WorkspaceMember{
+		WorkspaceID: "ws-1",
+		UserID:      "user-1",
+		Role:        models.WorkspaceRoleAdmin,
+	}).Exec(ctx)
+	require.NoError(t, err)
+
+	e := echo.New()
+	api := humaecho.NewWithGroup(e, e.Group("/api/v1"), huma.DefaultConfig("Test", "1.0.0"))
+	handler := NewOAuthHandler(db, crypto.NewTokenEncryptor("0123456789abcdef0123456789abcdef"), map[string]platform.Adapter{
+		providerName: adapter,
+	}, testAuthenticator{}, false, frontendURL)
+	handler.GetAuthURL(api)
+	handler.Callback(api)
+
+	authURLResp := oauthSelectionRequest(t, e, http.MethodGet, "/api/v1/accounts/"+providerName+"/auth-url?workspace_id=ws-1", nil, true)
+	require.Equal(t, http.StatusOK, authURLResp.Code, authURLResp.Body.String())
+	var authURLBody struct {
+		URL string `json:"url"`
+	}
+	require.NoError(t, json.Unmarshal(authURLResp.Body.Bytes(), &authURLBody))
+	parsedAuthURL, err := url.Parse(authURLBody.URL)
+	require.NoError(t, err)
+	state := parsedAuthURL.Query().Get("state")
+	require.NotEmpty(t, state)
+
+	return e, state
+}

--- a/backend/internal/api/handlers/oauth_selection_test.go
+++ b/backend/internal/api/handlers/oauth_selection_test.go
@@ -132,8 +132,10 @@ func TestOAuthCallbackCreatesAndCompletesAccountSelection(t *testing.T) {
 	require.NotEmpty(t, state)
 
 	callbackResp := oauthSelectionRequest(t, e, http.MethodGet, "/api/v1/accounts/selectable/callback?code=provider-code&state="+url.QueryEscape(state), nil, false)
-	require.Equal(t, http.StatusTemporaryRedirect, callbackResp.Code, callbackResp.Body.String())
-	location := callbackResp.Header().Get("Location")
+	callbackResult := callbackResp.Result()
+	t.Cleanup(func() { _ = callbackResult.Body.Close() })
+	require.Equal(t, http.StatusTemporaryRedirect, callbackResult.StatusCode, callbackResp.Body.String())
+	location := callbackResult.Header.Get("Location")
 	require.Contains(t, location, "status=selection_required")
 	require.Contains(t, location, "platform=selectable")
 	callbackURL, err := url.Parse(location)


### PR DESCRIPTION
## Root cause
Huma commits a streamed response when `SetStatus(307)` is called. The OAuth callbacks set `Location` afterward, so the finalized HTTP response had a 307 status but no redirect target. Existing tests inspected the recorder before finalization and missed it.

## Fix
- set `Location` before committing the 307 status for callback error and account-selection redirects
- assert against the finalized `http.Response`
- cover Facebook, Instagram, and Threads callback paths

## Verification
- full `backend/internal/api/handlers` package passes with a clean Go test cache
- formatting and `git diff --check` pass

Fixes #5