### PR TITLE
docs: replace broken star history

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ devenv shell -- verify
 
 See the [development setup](https://docs.openpost.social/development/setup) and [contributing guide](CONTRIBUTING.md).
 
-## Star history
+## Support OpenPost
 
-[![OpenPost stars](https://img.shields.io/github/stars/rodrgds/openpost?style=for-the-badge&label=OpenPost%20stars)](https://www.star-history.com/?repos=rodrgds%2Fopenpost&type=date&legend=top-left)
+If OpenPost helps you, star the repository. Your star helps more people find the project and shows us that the work is useful.
 
-[View OpenPost on Star History](https://www.star-history.com/?repos=rodrgds%2Fopenpost&type=date&legend=top-left).
+[![Star OpenPost on GitHub](https://img.shields.io/github/stars/rodrgds/openpost?style=for-the-badge&logo=github&label=Star%20OpenPost&color=f4b942)](https://github.com/rodrgds/openpost)
 
 ## License
 


### PR DESCRIPTION
## Summary

- remove the unavailable Star History links from the README
- replace them with a clear support call to action
- show the live GitHub star count in a larger Shields badge that links to the repository

## Why

GitHub restricted access to the timestamped stargazer data used by public star-history charts. The repository's total star count remains available, so the new badge provides a reliable visual and a direct path for readers to star OpenPost.

## Impact

README visitors see a working star count and a clearer explanation of how starring supports the project.

## Validation

- `git diff --check -- README.md`
- verified the Shields badge returns HTTP 200
- repository pre-push lint gate