### PR TITLE
fix(marketing): canonicalize documentation routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 
+- Redirected marketing-site documentation paths to the canonical docs site and restored real 404 responses for unknown paths.
 - Made Studio layer reordering work with touch drag handles on mobile, corrected one-direction drop placement, and kept keyboard reordering one step at a time.
 - Preserved image aspect ratios when Studio media metadata arrives before or after insertion, made stretch the default image fit, and enlarged canvas resize handles for touch.
 - Kept every grouped Studio child inside its group stacking slot so unrelated circles, images, and other layers cannot render between grouped text and shapes.

--- a/marketing-site/package.json
+++ b/marketing-site/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --host 0.0.0.0 --port 4322",
-    "build": "vite build",
+    "build": "vite build && node scripts/check-routing-output.mjs",
+    "check:routing": "node scripts/check-routing-output.mjs",
     "preview": "vite preview --host 0.0.0.0 --port 4322",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
   },

--- a/marketing-site/scripts/check-routing-output.mjs
+++ b/marketing-site/scripts/check-routing-output.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const siteRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const outputRoot = path.join(siteRoot, 'dist');
+
+const redirects = await readFile(path.join(outputRoot, '_redirects'), 'utf8');
+assert.equal(
+	redirects,
+	[
+		'/docs https://docs.openpost.social/ 301',
+		'/docs/* https://docs.openpost.social/:splat 301',
+		''
+	].join('\n'),
+	'marketing build must permanently redirect /docs and every /docs/* suffix to the canonical docs site'
+);
+
+const notFound = await readFile(path.join(outputRoot, '404.html'), 'utf8');
+assert.match(notFound, /<title>Page not found · OpenPost<\/title>/);
+assert.match(notFound, /<meta name="robots" content="noindex" \/>/);
+assert.match(notFound, /<h1>Page not found<\/h1>/);
+assert.match(notFound, /<a href="\/">Return to OpenPost<\/a>/);
+assert.doesNotMatch(
+	notFound,
+	/(?:href|src)="\.\/_app\//,
+	'top-level 404 must not depend on path-relative application assets'
+);
+
+console.log('Verified marketing redirect and top-level 404 build artifacts.');

--- a/marketing-site/static/404.html
+++ b/marketing-site/static/404.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="robots" content="noindex" />
+		<title>Page not found · OpenPost</title>
+		<style>
+			:root {
+				color-scheme: light;
+				font-family:
+					Arial,
+					system-ui,
+					sans-serif;
+				color: #171717;
+				background: #faf9f7;
+			}
+
+			body {
+				display: grid;
+				min-height: 100vh;
+				margin: 0;
+				place-items: center;
+			}
+
+			main {
+				max-width: 32rem;
+				padding: 2rem;
+				text-align: center;
+			}
+
+			p {
+				color: #5f5b57;
+				line-height: 1.6;
+			}
+
+			a {
+				color: inherit;
+				font-weight: 600;
+			}
+		</style>
+	</head>
+	<body>
+		<main>
+			<p>404</p>
+			<h1>Page not found</h1>
+			<p>The page you requested does not exist.</p>
+			<a href="/">Return to OpenPost</a>
+		</main>
+	</body>
+</html>

--- a/marketing-site/static/_redirects
+++ b/marketing-site/static/_redirects
@@ -1,0 +1,2 @@
+/docs https://docs.openpost.social/ 301
+/docs/* https://docs.openpost.social/:splat 301


### PR DESCRIPTION
## Summary

- redirect `/docs` and `/docs/*` to `docs.openpost.social`
- ship a real top-level `404.html` so Cloudflare Pages no longer treats the marketing site as an SPA
- verify both routing artifacts during every marketing build

## Verification

- `node scripts/sync-assets.mjs`
- `corepack pnpm --filter @openpost/site build`
- local `wrangler pages dev`: `/docs/mcp` → 301, unknown path → 404, `/` → 200