### PR TITLE
docs: add official MCP registry metadata

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.rodrgds/openpost",
+  "description": "Manage social publishing workflows through OpenPost",
+  "version": "1.32.1",
+  "repository": {
+    "url": "https://github.com/rodrgds/openpost",
+    "source": "github"
+  },
+  "websiteUrl": "https://docs.openpost.social/mcp/",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://app.openpost.social/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the source-controlled `server.json` used to publish OpenPost to the official MCP Registry.

The metadata describes the managed Streamable HTTP endpoint under the GitHub-authenticated `io.github.rodrgds/openpost` namespace. The official live registry validator returns `valid: true` with no issues, and the endpoint exposes the expected OAuth protected-resource metadata.

Validation:
- `jq empty server.json`
- official `POST /v0/validate`
- `git diff --check`