### PR TITLE
Add analytics to marketing and documentation sites

### DIFF
--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -178,6 +178,14 @@ export default defineConfig({
 		['meta', { property: 'og:title', content: 'OpenPost' }],
 		['meta', { property: 'og:description', content: 'Draft, adapt, schedule, and automate social posts with the managed OpenPost app or the same self-hosted product.' }],
 		['meta', { property: 'og:image', content: `${docsBase}assets/brand/og-image.png` }],
+		[
+			'script',
+			{
+				defer: '',
+				src: 'https://analytics.rgo.pt/script.js',
+				'data-website-id': 'fded0cc2-dbbf-4362-a0c2-494694a56621',
+			},
+		],
 	],
 	themeConfig: {
 		logo: '/assets/brand/icon.svg',

--- a/marketing-site/src/app.html
+++ b/marketing-site/src/app.html
@@ -4,6 +4,11 @@
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/icon.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script
+			defer
+			src="https://analytics.rgo.pt/script.js"
+			data-website-id="116c64a7-786b-437f-bb0d-e011e5e10a2b"
+		></script>
 		<script>
 			(() => {
 				try {

--- a/marketing-site/src/routes/privacy/+page.svelte
+++ b/marketing-site/src/routes/privacy/+page.svelte
@@ -2,7 +2,7 @@
   import { resolve } from "$app/paths";
   import { siteUrl } from "../_marketing";
 
-  const effectiveDate = "29 July 2026";
+  const effectiveDate = "30 July 2026";
 </script>
 
 <svelte:head>
@@ -72,6 +72,12 @@
         platform replies, access tokens, post text, or direct messages.
       </li>
       <li>
+        <strong>Website analytics data:</strong> anonymous page views, referrer URLs,
+        browser, operating system, device type, country, and selected interaction
+        events from openpost.social and docs.openpost.social. The website tracker
+        does not use cookies, identify visitors, or track people across websites.
+      </li>
+      <li>
         <strong>Brand font records:</strong> custom WOFF2, TTF, or OTF files, family
         and style details, and the account and time associated with the required font-license
         acknowledgement.
@@ -129,6 +135,10 @@
         Comply with law, enforce the Terms of Service, and resolve disputes.
       </li>
       <li>Improve the service using technical logs and error data.</li>
+      <li>
+        Understand anonymous traffic and selected interactions on the marketing
+        and documentation sites.
+      </li>
     </ul>
     <p>
       For users in the European Economic Area, these uses rely on performing our
@@ -149,7 +159,7 @@
       </li>
       <li>
         <strong>Hosting companies</strong> that run the app, database, media, email,
-        network, and backups under their service terms.
+        network, analytics, and backups under their service terms.
       </li>
       <li>
         <strong>Polar</strong> for checkout, subscriptions, billing, and customer
@@ -221,8 +231,14 @@
       Studio background removal runs in your browser with model and runtime
       files served by the OpenPost operator. Source pixels are not sent to a
       background-removal service. A result is uploaded to the selected workspace
-      only when processing succeeds. The marketing site does not use advertising
-      trackers. The privacy-enhanced YouTube player is loaded only when you open
+      only when processing succeeds.
+    </p>
+    <p>
+      The marketing and documentation sites use self-hosted, cookie-free Umami
+      analytics to measure anonymous traffic and selected interactions. They do
+      not use advertising trackers, identify visitors, or track people across
+      websites. The hosted application does not load this website analytics
+      tracker. The privacy-enhanced YouTube player is loaded only when you open
       the product demo; YouTube may then process device and playback data.
     </p>
     <p>


### PR DESCRIPTION
## What changed

- load the self-hosted Umami tracker on `openpost.social` using its dedicated website ID
- load the tracker on `docs.openpost.social` using a separate documentation website ID
- update the privacy policy to describe the anonymous, cookie-free website analytics
- explicitly document that `app.openpost.social` does not load the website analytics tracker

## Why

The two public content sites had Umami websites configured, but their tracking scripts were not present in the repository. Existing `data-umami-event` attributes on marketing CTAs therefore could not emit events.

## Impact

Marketing and documentation traffic will now appear in their respective Umami dashboards after deployment. The authenticated application remains untracked.

## Validation

- verified both script URLs and website IDs in the committed files
- verified the VitePress script entry is inside the global `head` configuration
- compared the branch against `main`: three intended files changed, no unrelated changes

Full local builds were not run because the repository checkout is not mounted in this session.