### PR TITLE
fix: accept composer links during capability resolution

### DIFF
--- a/backend/internal/api/handlers/capability_resolver.go
+++ b/backend/internal/api/handlers/capability_resolver.go
@@ -126,6 +126,7 @@ func (h *CapabilityResolverHandler) RegisterRoutes(api huma.API) {
 				segments,
 				&resolved,
 			)
+			satisfyCanonicalURLRequirement(&resolved, input.Body.SourceURL, segments)
 			output.Body.Accounts = append(output.Body.Accounts, ResolvedAccountCapability{
 				AccountID:          account.ID,
 				ResolvedCapability: resolved,
@@ -327,6 +328,45 @@ func (h *CapabilityResolverHandler) mergeAccountCapability(
 		if len(resolved.DynamicOptions[setting.OptionsSource]) == 0 {
 			h.addDynamicCapabilityFailure(resolved, settings, setting.Label+" options are not available.")
 			return
+		}
+	}
+}
+
+func satisfyCanonicalURLRequirement(
+	resolved *capabilities.ResolvedCapability,
+	sourceURL string,
+	segments []capabilities.ResolveSegment,
+) {
+	if resolved == nil || resolved.ActiveConstraints["media_shape"] != capabilities.MediaShapeLink {
+		return
+	}
+	hasURL := strings.TrimSpace(sourceURL) != ""
+	for _, segment := range segments {
+		hasURL = hasURL || strings.TrimSpace(segment.URL) != ""
+	}
+	if !hasURL {
+		return
+	}
+
+	issues := resolved.Issues[:0]
+	removed := false
+	for _, issue := range resolved.Issues {
+		if issue.Code == "setting_required" && (issue.Field == "url" || issue.Field == "link_url") {
+			removed = true
+			continue
+		}
+		issues = append(issues, issue)
+	}
+	if !removed {
+		return
+	}
+
+	resolved.Issues = issues
+	resolved.Compatible = strings.TrimSpace(resolved.UnavailableReason) == ""
+	for _, issue := range issues {
+		if issue.Severity == "error" {
+			resolved.Compatible = false
+			break
 		}
 	}
 }

--- a/backend/internal/api/handlers/capability_resolver_link_test.go
+++ b/backend/internal/api/handlers/capability_resolver_link_test.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/openpost/backend/internal/capabilities"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSatisfyCanonicalURLRequirement(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourceURL  string
+		segmentURL string
+	}{
+		{name: "source URL", sourceURL: "https://example.com"},
+		{name: "segment URL", segmentURL: "https://example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			segments := []capabilities.ResolveSegment{{
+				ID:   "segment-1",
+				Body: "A link post",
+				URL:  tt.segmentURL,
+			}}
+			resolved := capabilities.Resolve(capabilities.ProviderX, capabilities.ResolveInput{
+				Intent:    capabilities.IntentPost,
+				SourceURL: tt.sourceURL,
+				Segments:  segments,
+			})
+
+			require.Equal(t, capabilities.MediaShapeLink, resolved.ActiveConstraints["media_shape"])
+			require.True(t, hasCapabilityIssue(resolved.Issues, "setting_required", "url"))
+			require.False(t, resolved.Compatible)
+
+			satisfyCanonicalURLRequirement(&resolved, tt.sourceURL, segments)
+
+			require.False(t, hasCapabilityIssue(resolved.Issues, "setting_required", "url"))
+			require.True(t, resolved.Compatible)
+		})
+	}
+}
+
+func TestSatisfyCanonicalURLRequirementNeedsCanonicalURL(t *testing.T) {
+	resolved := capabilities.ResolvedCapability{
+		Compatible: false,
+		ActiveConstraints: map[string]any{
+			"media_shape": capabilities.MediaShapeLink,
+		},
+		Issues: []capabilities.ValidationIssue{{
+			Severity: "error",
+			Code:     "setting_required",
+			Field:    "url",
+		}},
+	}
+
+	satisfyCanonicalURLRequirement(&resolved, "", nil)
+
+	require.True(t, hasCapabilityIssue(resolved.Issues, "setting_required", "url"))
+	require.False(t, resolved.Compatible)
+}
+
+func TestSatisfyCanonicalURLRequirementKeepsOtherErrors(t *testing.T) {
+	resolved := capabilities.ResolvedCapability{
+		Compatible: false,
+		ActiveConstraints: map[string]any{
+			"media_shape": capabilities.MediaShapeLink,
+		},
+		Issues: []capabilities.ValidationIssue{
+			{
+				Severity: "error",
+				Code:     "setting_required",
+				Field:    "link_url",
+			},
+			{
+				Severity: "error",
+				Code:     "other_error",
+				Field:    "body",
+			},
+		},
+	}
+
+	satisfyCanonicalURLRequirement(&resolved, "https://example.com", nil)
+
+	require.False(t, hasCapabilityIssue(resolved.Issues, "setting_required", "link_url"))
+	require.True(t, hasCapabilityIssue(resolved.Issues, "other_error", "body"))
+	require.False(t, resolved.Compatible)
+}
+
+func hasCapabilityIssue(issues []capabilities.ValidationIssue, code string, field string) bool {
+	for _, issue := range issues {
+		if issue.Code == code && issue.Field == field {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What changed

- treat the canonical composer `source_url`/first-segment URL as satisfying link-profile URL requirements during account capability resolution
- remove only the false `setting_required` issue for `url` or `link_url`
- preserve unrelated validation errors and provider-unavailable states
- add focused regression coverage for source URLs, segment URLs, missing URLs, and unrelated errors

## Root cause

The text-and-thread composer correctly sent the link as canonical `source_url` and on its first segment. The capability resolver selected each provider's link profile, but validated the profile with `nil` destination settings, so every provider using the required `url` setting emitted `URL is required`. Bluesky behaved differently because its final setting key is `link_url` and the payload builder handled it separately.

## Testing

The PR adds handler-level regression tests. Full repository CI is expected to run on this pull request.