### PR TITLE
Add workspace creation to the workspace switcher

### DIFF
--- a/e2e-app/workspace-switcher.spec.ts
+++ b/e2e-app/workspace-switcher.spec.ts
@@ -37,6 +37,54 @@ test("sidebar footer switches between workspaces", async ({
   await expect(workspaceButton).toContainText(nextWorkspace);
 });
 
+test("workspace switcher creates and selects a workspace", async ({
+  page,
+  request,
+}) => {
+  const unique = Date.now().toString(36);
+  const email = `workspace-create-${unique}@example.com`;
+  const firstName = `Personal ${unique}`;
+  const newName = `Project ${unique}`;
+
+  const auth = await registerUser(request, email);
+  await createWorkspace(request, auth.token, firstName);
+
+  await authenticatePage(page, auth.token);
+  await page.goto("/");
+
+  const workspaceButton = page
+    .getByRole("button", { name: new RegExp(firstName) })
+    .first();
+  await expect(workspaceButton).toBeVisible();
+
+  await workspaceButton.click();
+  await page.getByRole("menuitem", { name: "Create workspace" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(
+    dialog.getByRole("heading", { name: "Create workspace" }),
+  ).toBeVisible();
+  await dialog.getByLabel("Workspace name").fill(newName);
+
+  const createResponse = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return (
+      url.pathname === "/api/v1/workspaces" &&
+      response.request().method() === "POST"
+    );
+  });
+  await dialog.getByRole("button", { name: "Create workspace" }).click();
+  expect((await createResponse).ok()).toBe(true);
+
+  await expect(dialog).toBeHidden();
+  await expect(workspaceButton).toContainText(newName);
+
+  await workspaceButton.click();
+  await expect(
+    page.getByRole("menuitem", { name: new RegExp(newName) }),
+  ).toBeVisible();
+});
+
 test("workspace-scoped pages reload when the sidebar workspace changes", async ({
   page,
   request,

--- a/e2e-app/workspace-switcher.spec.ts
+++ b/e2e-app/workspace-switcher.spec.ts
@@ -53,7 +53,7 @@ test("workspace switcher creates and selects a workspace", async ({
   await page.goto("/");
 
   const workspaceButton = page
-    .getByRole("button", { name: new RegExp(firstName) })
+    .getByRole("button", { name: new RegExp(`${firstName}|${newName}`) })
     .first();
   await expect(workspaceButton).toBeVisible();
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "pnpm run check:i18n && pnpm run generate:i18n && pnpm run check:types && svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --write src/lib/components/create-workspace-dialog.svelte && git diff -- src/lib/components/create-workspace-dialog.svelte && exit 1",
+		"lint": "prettier --check . && eslint .",
 		"format": "prettier --write .",
 		"test:unit": "vitest",
 		"test": "pnpm run test:unit -- --run",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "pnpm run check:i18n && pnpm run generate:i18n && pnpm run check:types && svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --check . && eslint .",
+		"lint": "prettier --write src/lib/components/create-workspace-dialog.svelte && git diff -- src/lib/components/create-workspace-dialog.svelte && exit 1",
 		"format": "prettier --write .",
 		"test:unit": "vitest",
 		"test": "pnpm run test:unit -- --run",

--- a/frontend/src/lib/components/account-preferences-menu.svelte
+++ b/frontend/src/lib/components/account-preferences-menu.svelte
@@ -33,9 +33,10 @@
 	interface Props {
 		showDestinations?: boolean;
 		onNavigate?: () => void;
+		onCreateWorkspace?: () => void;
 	}
 
-	let { showDestinations = false, onNavigate }: Props = $props();
+	let { showDestinations = false, onNavigate, onCreateWorkspace }: Props = $props();
 	let workspacesExpanded = $state(false);
 	const menuItemClass = $derived(showDestinations ? 'min-h-11' : '');
 
@@ -100,6 +101,7 @@
 			<WorkspaceMenuItems
 				touchSize
 				showLabel={false}
+				onCreate={onCreateWorkspace}
 				onSelect={() => {
 					workspacesExpanded = false;
 					onNavigate?.();

--- a/frontend/src/lib/components/create-workspace-dialog.svelte
+++ b/frontend/src/lib/components/create-workspace-dialog.svelte
@@ -48,7 +48,10 @@
 			open = false;
 			reset();
 		} catch (cause) {
-			error = cause instanceof Error && cause.message ? cause.message : m.onboarding_create_failed();
+			error =
+				cause instanceof Error && cause.message
+					? cause.message
+					: m.onboarding_create_failed();
 		} finally {
 			pending = false;
 		}

--- a/frontend/src/lib/components/create-workspace-dialog.svelte
+++ b/frontend/src/lib/components/create-workspace-dialog.svelte
@@ -52,7 +52,8 @@
 			open = false;
 			reset();
 		} catch (cause) {
-			error = cause instanceof Error && cause.message ? cause.message : m.onboarding_create_failed();
+			error =
+				cause instanceof Error && cause.message ? cause.message : m.onboarding_create_failed();
 		} finally {
 			pending = false;
 		}

--- a/frontend/src/lib/components/create-workspace-dialog.svelte
+++ b/frontend/src/lib/components/create-workspace-dialog.svelte
@@ -52,10 +52,7 @@
 			open = false;
 			reset();
 		} catch (cause) {
-			error =
-				cause instanceof Error && cause.message
-					? cause.message
-					: m.onboarding_create_failed();
+			error = cause instanceof Error && cause.message ? cause.message : m.onboarding_create_failed();
 		} finally {
 			pending = false;
 		}

--- a/frontend/src/lib/components/create-workspace-dialog.svelte
+++ b/frontend/src/lib/components/create-workspace-dialog.svelte
@@ -24,10 +24,14 @@
 		error = '';
 	}
 
+	function handleOpenChange(isOpen: boolean) {
+		if (!isOpen && pending) return;
+		open = isOpen;
+		if (!isOpen) reset();
+	}
+
 	function close() {
-		if (pending) return;
-		open = false;
-		reset();
+		handleOpenChange(false);
 	}
 
 	async function createWorkspace(event: SubmitEvent) {
@@ -58,7 +62,7 @@
 	}
 </script>
 
-<Dialog.Root bind:open>
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
 	<Dialog.Content aria-busy={pending} showCloseButton={false} class="sm:max-w-md">
 		<form onsubmit={createWorkspace} class="space-y-4">
 			<Dialog.Header>

--- a/frontend/src/lib/components/create-workspace-dialog.svelte
+++ b/frontend/src/lib/components/create-workspace-dialog.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import InlineNotice from '$lib/components/inline-notice.svelte';
+	import LoaderIcon from 'lucide-svelte/icons/loader-2';
+	import { client } from '$lib/api/client';
+	import { workspaceCtx } from '$lib/stores/workspace.svelte';
+	import { m } from '$lib/paraglide/messages';
+
+	interface Props {
+		open?: boolean;
+	}
+
+	let { open = $bindable(false) }: Props = $props();
+	let workspaceName = $state('');
+	let error = $state('');
+	let pending = $state(false);
+	const canCreate = $derived(Boolean(workspaceName.trim()) && !pending);
+
+	function reset() {
+		workspaceName = '';
+		error = '';
+	}
+
+	function close() {
+		if (pending) return;
+		open = false;
+		reset();
+	}
+
+	async function createWorkspace(event: SubmitEvent) {
+		event.preventDefault();
+		const name = workspaceName.trim();
+		if (!name || pending) return;
+
+		pending = true;
+		error = '';
+		try {
+			const { data, error: responseError } = await client.POST('/workspaces', {
+				body: { name }
+			});
+			if (responseError || !data?.id) {
+				throw new Error(responseError?.detail || m.onboarding_create_failed());
+			}
+			await workspaceCtx.loadWorkspaces(data.id);
+			open = false;
+			reset();
+		} catch (cause) {
+			error = cause instanceof Error && cause.message ? cause.message : m.onboarding_create_failed();
+		} finally {
+			pending = false;
+		}
+	}
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content aria-busy={pending} showCloseButton={false} class="sm:max-w-md">
+		<form onsubmit={createWorkspace} class="space-y-4">
+			<Dialog.Header>
+				<Dialog.Title>{m.onboarding_submit()}</Dialog.Title>
+				<Dialog.Description>{m.onboarding_workspace_hint()}</Dialog.Description>
+			</Dialog.Header>
+
+			{#if error}
+				<InlineNotice tone="error" message={error} />
+			{/if}
+
+			<div class="space-y-2">
+				<Label for="new-workspace-name">{m.onboarding_workspace_name()}</Label>
+				<Input
+					id="new-workspace-name"
+					bind:value={workspaceName}
+					placeholder={m.onboarding_workspace_placeholder()}
+					disabled={pending}
+					autocomplete="off"
+					autofocus
+				/>
+			</div>
+
+			<Dialog.Footer>
+				<Button type="button" variant="outline" disabled={pending} onclick={close}>
+					{m.common_cancel()}
+				</Button>
+				<Button type="submit" class="gap-2" disabled={!canCreate}>
+					{#if pending}<LoaderIcon class="size-4 animate-spin" />{/if}
+					{m.onboarding_submit()}
+				</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/frontend/src/lib/components/sidebar-left.svelte
+++ b/frontend/src/lib/components/sidebar-left.svelte
@@ -18,6 +18,7 @@
 	import SidebarPlanner from './sidebar-planner.svelte';
 	import AccountPreferencesMenu from './account-preferences-menu.svelte';
 	import WorkspaceMenuItems from './workspace-menu-items.svelte';
+	import CreateWorkspaceDialog from './create-workspace-dialog.svelte';
 	import CalendarIcon from 'lucide-svelte/icons/calendar-days';
 	import ComposeIcon from 'lucide-svelte/icons/square-pen';
 	import PostsIcon from 'lucide-svelte/icons/files';
@@ -31,6 +32,7 @@
 	import NotificationBell from './notification-bell.svelte';
 
 	let authState = $derived($auth);
+	let createWorkspaceOpen = $state(false);
 	const sidebar = Sidebar.useSidebar();
 	const currentPath = $derived(page.url.pathname);
 	const currentWorkspaceName = $derived(
@@ -119,6 +121,11 @@
 		return initials(workspace?.name || 'Workspace');
 	}
 
+	function openCreateWorkspace() {
+		sidebar.setOpenMobile(false);
+		createWorkspaceOpen = true;
+	}
+
 	function navigate(href: string) {
 		sidebar.setOpenMobile(false);
 		if (href === '/') ui.startNewPost();
@@ -197,7 +204,10 @@
 				align="start"
 				sideOffset={6}
 			>
-				<WorkspaceMenuItems onSelect={() => sidebar.setOpenMobile(false)} />
+				<WorkspaceMenuItems
+					onCreate={openCreateWorkspace}
+					onSelect={() => sidebar.setOpenMobile(false)}
+				/>
 			</DropdownMenu.Content>
 		</DropdownMenu.Root>
 	</Sidebar.Header>
@@ -295,7 +305,10 @@
 						align="end"
 						sideOffset={6}
 					>
-						<AccountPreferencesMenu onNavigate={() => sidebar.setOpenMobile(false)} />
+						<AccountPreferencesMenu
+							onCreateWorkspace={openCreateWorkspace}
+							onNavigate={() => sidebar.setOpenMobile(false)}
+						/>
 					</DropdownMenu.Content>
 				</DropdownMenu.Root>
 			</Sidebar.MenuItem>
@@ -303,6 +316,8 @@
 	</Sidebar.Footer>
 	<Sidebar.Rail />
 </Sidebar.Root>
+
+<CreateWorkspaceDialog bind:open={createWorkspaceOpen} />
 
 <style>
 	.sidebar-context-swap {

--- a/frontend/src/lib/components/workspace-menu-items.svelte
+++ b/frontend/src/lib/components/workspace-menu-items.svelte
@@ -6,17 +6,25 @@
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import * as Avatar from '$lib/components/ui/avatar';
 	import CheckIcon from 'lucide-svelte/icons/check';
+	import PlusIcon from 'lucide-svelte/icons/plus';
 	import SettingsIcon from 'lucide-svelte/icons/settings';
 	import type { Workspace } from '$lib/api/client';
 
 	interface Props {
 		touchSize?: boolean;
 		onSelect?: () => void;
+		onCreate?: () => void;
 		showLabel?: boolean;
 		showSettings?: boolean;
 	}
 
-	let { touchSize = false, onSelect, showLabel = true, showSettings = true }: Props = $props();
+	let {
+		touchSize = false,
+		onSelect,
+		onCreate,
+		showLabel = true,
+		showSettings = true
+	}: Props = $props();
 	const itemClass = $derived(touchSize ? 'min-h-11 gap-3' : 'gap-3 py-2');
 
 	function initials(value: string) {
@@ -33,6 +41,11 @@
 			await workspaceCtx.setWorkspace(workspace);
 		}
 		onSelect?.();
+	}
+
+	function createWorkspace() {
+		onSelect?.();
+		onCreate?.();
 	}
 
 	function openWorkspaceSettings() {
@@ -62,8 +75,16 @@
 		{m.sidebar_no_workspaces()}
 	</DropdownMenu.Item>
 {/if}
-{#if showSettings}
+{#if onCreate || showSettings}
 	<DropdownMenu.Separator />
+{/if}
+{#if onCreate}
+	<DropdownMenu.Item class={touchSize ? 'min-h-11' : ''} onclick={createWorkspace}>
+		<PlusIcon class="mr-2 size-4 text-muted-foreground" />
+		{m.onboarding_submit()}
+	</DropdownMenu.Item>
+{/if}
+{#if showSettings}
 	<DropdownMenu.Item class={touchSize ? 'min-h-11' : ''} onclick={openWorkspaceSettings}>
 		<SettingsIcon class="mr-2 size-4 text-muted-foreground" />
 		{m.sidebar_workspace_settings()}


### PR DESCRIPTION
## What changed

- adds a localized **Create workspace** action to the workspace switcher
- opens a small name dialog from both desktop and mobile workspace menus
- creates the workspace through the existing `POST /workspaces` endpoint
- refreshes the workspace store and immediately selects the new workspace
- adds an end-to-end regression test for the complete creation flow

## Why

The backend already supported creating additional workspaces, but the frontend only exposed workspace creation during first-run onboarding. Once a user had a workspace, there was no UI path to create another one.

## Validation

- Playwright coverage added in `e2e-app/workspace-switcher.spec.ts`
- formatting, ESLint, generated-contract checks, and Svelte type checks passed
- frontend unit tests and all web, marketing, and documentation builds passed
- all three Playwright suites passed
- security checks passed