### PR TITLE
feat: add OpenPost Discord community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
   <a href="https://docs.openpost.social/guide/quickstart"><strong>Quickstart</strong></a>
   ·
   <a href="https://docs.openpost.social/self-hosting/"><strong>Self-hosting docs</strong></a>
+  ·
+  <a href="https://discord.gg/u2QwukmY4W"><strong>Discord community</strong></a>
 </p>
 
 <p align="center">
@@ -144,6 +146,8 @@ devenv shell -- verify
 ```
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) and the [development docs](https://docs.openpost.social/development/setup) before opening a pull request. Bug reports, focused feature proposals, documentation fixes, and tested provider improvements are welcome.
+
+For setup questions, ideas, and general discussion, join the [OpenPost Discord community](https://discord.gg/u2QwukmY4W).
 
 ## Help OpenPost grow
 

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -197,8 +197,12 @@ export default defineConfig({
 			{ text: 'Self-Hosting', link: '/self-hosting/' },
 			{ text: 'Providers', link: '/providers/overview' },
 			{ text: 'Developer Docs', link: '/development/' },
+			{ text: 'Community', link: 'https://discord.gg/u2QwukmY4W' },
 		],
-		socialLinks: [{ icon: 'github', link: 'https://github.com/rodrgds/openpost' }],
+		socialLinks: [
+			{ icon: 'github', link: 'https://github.com/rodrgds/openpost' },
+			{ icon: 'discord', link: 'https://discord.gg/u2QwukmY4W' },
+		],
 		search: {
 			provider: 'local',
 		},

--- a/e2e/marketing.spec.ts
+++ b/e2e/marketing.spec.ts
@@ -76,6 +76,9 @@ test("marketing index links to the app and documentation", async ({ page }) => {
   await expect(
     page.getByRole("link", { name: "GitHub source" }),
   ).toHaveAttribute("href", "https://github.com/rodrgds/openpost");
+  await expect(
+    page.getByRole("link", { name: "Discord community", exact: true }).last(),
+  ).toHaveAttribute("href", "https://discord.gg/u2QwukmY4W");
 });
 
 test("security page states AI tool access accurately", async ({ page }) => {
@@ -124,6 +127,12 @@ test("marketing navigation uses the shared responsive menu patterns", async ({
     await expect(
       navigation.getByRole("link", { name: "Changelog", exact: true }),
     ).toHaveAttribute("href", "/changelog");
+    await expect(
+      navigation.getByRole("link", {
+        name: "Discord community",
+        exact: true,
+      }),
+    ).toHaveAttribute("href", "https://discord.gg/u2QwukmY4W");
     await page.keyboard.press("Escape");
     return;
   }
@@ -136,6 +145,12 @@ test("marketing navigation uses the shared responsive menu patterns", async ({
   await expect(
     navigation.getByRole("link", { name: "Changelog", exact: true }),
   ).toHaveAttribute("href", "/changelog");
+  await expect(
+    navigation.getByRole("link", {
+      name: "Discord community",
+      exact: true,
+    }),
+  ).toHaveAttribute("href", "https://discord.gg/u2QwukmY4W");
 });
 
 test("marketing SEO routes expose the current public index", async ({

--- a/marketing-site/src/routes/_components/MarketingFooter.svelte
+++ b/marketing-site/src/routes/_components/MarketingFooter.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Github from "lucide-svelte/icons/github";
+  import MessageCircle from "lucide-svelte/icons/message-circle";
   import Logo from "$lib/components/Logo.svelte";
   import {
     developerDocsUrl,
@@ -9,6 +10,8 @@
     selfHostingDocsUrl,
     userDocsUrl,
   } from "../_marketing";
+
+  const discordCommunityUrl = "https://discord.gg/u2QwukmY4W";
 
   const groups = [
     {
@@ -57,15 +60,26 @@
         Write one post, tailor it for each account, and preview it before it
         goes live.
       </p>
-      <a
-        href={githubUrl}
-        target="_blank"
-        rel="noreferrer"
-        class="focus-ring mt-5 inline-flex min-h-11 items-center gap-2 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground"
-      >
-        <Github class="size-4" />
-        GitHub source
-      </a>
+      <div class="mt-5 flex flex-wrap gap-x-5">
+        <a
+          href={githubUrl}
+          target="_blank"
+          rel="noreferrer"
+          class="focus-ring inline-flex min-h-11 items-center gap-2 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground"
+        >
+          <Github class="size-4" />
+          GitHub source
+        </a>
+        <a
+          href={discordCommunityUrl}
+          target="_blank"
+          rel="noreferrer"
+          class="focus-ring inline-flex min-h-11 items-center gap-2 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground"
+        >
+          <MessageCircle class="size-4" />
+          Discord community
+        </a>
+      </div>
     </div>
 
     <div class="grid gap-8 sm:grid-cols-3">

--- a/marketing-site/src/routes/_components/MarketingNav.svelte
+++ b/marketing-site/src/routes/_components/MarketingNav.svelte
@@ -15,6 +15,13 @@
 
   let mobileOpen = $state(false);
   const currentPath = $derived(page.url.pathname);
+  const navigationResourceItems = [
+    ...resourceItems,
+    {
+      label: "Discord community",
+      href: "https://discord.gg/u2QwukmY4W",
+    },
+  ] as const;
 
   function isActive(href: string): boolean {
     if (href.startsWith("http")) return false;
@@ -23,7 +30,7 @@
   }
 
   function resourcesActive(): boolean {
-    return resourceItems.some((item) => isActive(item.href));
+    return navigationResourceItems.some((item) => isActive(item.href));
   }
 </script>
 
@@ -66,7 +73,7 @@
           </NavigationMenu.Trigger>
           <NavigationMenu.Content class="w-56">
             <ul class="grid gap-1">
-              {#each resourceItems as item (item.href)}
+              {#each navigationResourceItems as item (item.href)}
                 <li>
                   <NavigationMenu.Link
                     href={item.href}
@@ -154,7 +161,7 @@
         <p class="mt-3 px-3 text-xs font-semibold text-muted-foreground">
           Resources
         </p>
-        {#each resourceItems as item (item.href)}
+        {#each navigationResourceItems as item (item.href)}
           <a
             href={item.href}
             class="focus-ring flex min-h-11 items-center rounded-md px-3 text-sm text-muted-foreground"


### PR DESCRIPTION
## What changed

- adds the OpenPost Discord community to the marketing footer
- adds Discord to the desktop and mobile Resources navigation
- adds Community navigation and a Discord social icon to the docs site
- links the community from the repository README
- adds Playwright coverage for the public Discord links

## Why

OpenPost now has an official community server, but there was no discoverable path to it from the website, documentation, or repository overview.

## Release

This is intended for the next minor release alongside the workspace-creation feature and composer-link fix shipped since v1.44.4.

## Validation

- formatting, lint, generated-contract, and Svelte checks passed
- frontend, marketing, and documentation builds passed
- unit tests and all Playwright suites passed
- security checks passed