### PR TITLE
chore: trigger v1.45.0 release observer

### DIFF
--- a/.github/workflows/observe-v1.45.0.yml
+++ b/.github/workflows/observe-v1.45.0.yml
@@ -1,3 +1,4 @@
+# Triggered through a merged pull request so GitHub emits the workflow event.
 name: Observe v1.45.0 release
 
 on:


### PR DESCRIPTION
Triggers the one-shot release observer through a merged pull request so GitHub emits the workflow event. The observer records the exact v1.45.0 Build and Release run on PR #27, then removes itself from main.