### PR TITLE
chore: dispatch v1.45.0 release

### DIFF
--- a/.github/workflows/dispatch-v1.45.0.yml
+++ b/.github/workflows/dispatch-v1.45.0.yml
@@ -1,0 +1,40 @@
+name: Dispatch v1.45.0 release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/dispatch-v1.45.0.yml"
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch release when missing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch the audited release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing="$(
+            gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow release.yml \
+              --limit 30 \
+              --json databaseId,headBranch \
+              --jq '.[] | select(.headBranch == "v1.45.0") | .databaseId' \
+              | head -n 1
+          )"
+
+          if [[ -n "$existing" ]]; then
+            echo "Build and Release already exists for v1.45.0: $existing"
+            exit 0
+          fi
+
+          gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref v1.45.0
+          echo "Dispatched Build and Release for v1.45.0"


### PR DESCRIPTION
Idempotently dispatches the existing Build and Release workflow for v1.45.0 only when no run for that tag exists. This works around the original bootstrap dispatch not registering.