### PR TITLE
fix(telemetry): preserve error context across transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
 ### Fixed
 
 - Prevented repeated desktop or mobile New post actions from orphaning the replacement composer's account-loading state, so the Social Set and platform controls no longer disappear behind a permanent loading indicator.
+- Preserved PostHog exception structure while adding application context, removed sensitive absolute URLs from browser stacks without dropping static source-map locations, propagated browser correlation through raw media transports, and added the marketing SvelteKit error boundary.
 - Normalized publication authorization times to database precision so immediate publishes cannot fail before reaching a provider, and surfaced terminal preflight failures as failed instead of leaving them scheduled and pending.
 - Scoped the Posts page totals and pagination to the selected Scheduled, Published, Failed, or Drafts tab instead of showing whole-history counts beside a filtered tab.
 - Removed the three-item cap from the desktop draft planner, made long draft lists scroll, grouped Editors, Accounts, and Settings consistently, and added a compact animated collapse control for the lower workspace navigation.

--- a/backend/internal/telemetry/telemetry.go
+++ b/backend/internal/telemetry/telemetry.go
@@ -106,19 +106,11 @@ func New(config Config) (Recorder, error) {
 	}
 
 	client, err := posthog.NewWithConfig(config.ProjectToken, posthog.Config{
-		Endpoint:        config.Endpoint,
-		DisableGeoIP:    posthog.Ptr(true),
-		ShutdownTimeout: 5 * time.Second,
-		DefaultEventProperties: posthog.Properties{
-			"surface":                 "backend",
-			"environment":             config.Environment,
-			"edition":                 config.Edition,
-			"version":                 config.Version,
-			"revision":                config.Revision,
-			"service":                 "openpost",
-			"$process_person_profile": false,
-		},
-		Callback: deliveryCallback{},
+		Endpoint:               config.Endpoint,
+		DisableGeoIP:           posthog.Ptr(true),
+		ShutdownTimeout:        5 * time.Second,
+		DefaultEventProperties: defaultEventProperties(config),
+		Callback:               deliveryCallback{},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize PostHog telemetry: %w", err)
@@ -169,6 +161,11 @@ func (r *postHogRecorder) Capture(ctx context.Context, event Event) error {
 func (r *noopRecorder) Capture(context.Context, Event) error { return nil }
 
 func (r *postHogRecorder) CaptureException(ctx context.Context, exception Exception) error {
+	message := newExceptionMessage(exception, r.config, time.Now().UTC())
+	return posthog.EnqueueWithContext(ctx, r.client, message)
+}
+
+func newExceptionMessage(exception Exception, config Config, timestamp time.Time) posthog.Exception {
 	title := strings.TrimSpace(exception.Title)
 	if title == "" {
 		title = "OpenPost error"
@@ -178,16 +175,35 @@ func (r *postHogRecorder) CaptureException(ctx context.Context, exception Except
 		description = "An OpenPost operation failed"
 	}
 	message := posthog.NewDefaultException(
-		time.Now().UTC(),
+		timestamp,
 		exceptionDistinctID(exception.DistinctID, exception.WorkspaceID),
 		title,
 		description,
 	)
-	message.Properties = posthog.Properties(copyProperties(exception.Properties))
+	// posthog-go stores the title, description, stack trace, and debug images
+	// outside Properties. Adding OpenPost context here must not replace those
+	// SDK-owned exception fields.
+	properties := copyProperties(exception.Properties)
+	for key, value := range defaultEventProperties(config) {
+		properties[key] = value
+	}
+	message.Properties = posthog.Properties(properties)
 	if exception.WorkspaceID != "" {
 		message.Properties["workspace_id"] = exception.WorkspaceID
 	}
-	return posthog.EnqueueWithContext(ctx, r.client, message)
+	return message
+}
+
+func defaultEventProperties(config Config) posthog.Properties {
+	return posthog.Properties{
+		"surface":                 "backend",
+		"environment":             config.Environment,
+		"edition":                 config.Edition,
+		"version":                 config.Version,
+		"revision":                config.Revision,
+		"service":                 "openpost",
+		"$process_person_profile": false,
+	}
 }
 
 func (r *noopRecorder) CaptureException(context.Context, Exception) error { return nil }

--- a/backend/internal/telemetry/telemetry_test.go
+++ b/backend/internal/telemetry/telemetry_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	posthog "github.com/posthog/posthog-go"
 	"github.com/stretchr/testify/require"
@@ -65,4 +66,36 @@ func TestMemoryRecorderPreservesApplicationEventContract(t *testing.T) {
 	require.Len(t, recorder.Events, 1)
 	require.Equal(t, "user-1", recorder.Events[0].DistinctID)
 	require.Equal(t, "publication-1", recorder.Events[0].Properties["publication_id"])
+}
+
+func TestExceptionMessagePreservesPostHogPayloadAndOpenPostContext(t *testing.T) {
+	timestamp := time.Date(2026, time.August, 11, 17, 0, 0, 0, time.UTC)
+	message := newExceptionMessage(Exception{
+		Title:       "Publication failed",
+		Description: "provider returned an error",
+		DistinctID:  "user-1",
+		WorkspaceID: "workspace-1",
+		Properties:  map[string]any{"route_template": "/api/v1/publications/{id}"},
+	}, Config{
+		Environment: "production",
+		Edition:     "cloud",
+		Version:     "v3.9.0",
+		Revision:    "abc123",
+	}, timestamp)
+
+	require.Equal(t, timestamp, message.Timestamp)
+	require.Equal(t, "user-1", message.DistinctId)
+	require.Len(t, message.ExceptionList, 1)
+	require.Equal(t, "Publication failed", message.ExceptionList[0].Type)
+	require.Equal(t, "provider returned an error", message.ExceptionList[0].Value)
+	require.NotNil(t, message.ExceptionList[0].Stacktrace)
+	require.Equal(t, "/api/v1/publications/{id}", message.Properties["route_template"])
+	require.Equal(t, "workspace-1", message.Properties["workspace_id"])
+	require.Equal(t, "backend", message.Properties["surface"])
+	require.Equal(t, "production", message.Properties["environment"])
+	require.Equal(t, "cloud", message.Properties["edition"])
+	require.Equal(t, "v3.9.0", message.Properties["version"])
+	require.Equal(t, "abc123", message.Properties["revision"])
+	require.Equal(t, "openpost", message.Properties["service"])
+	require.Equal(t, false, message.Properties["$process_person_profile"])
 }

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -2,7 +2,7 @@ import createClient from 'openapi-fetch';
 import type { paths, components } from './types';
 import { getApiBase } from '$lib/stores/instance.svelte';
 import { feedbackDiagnostics } from '$lib/feedback-diagnostics';
-import { telemetryRequestHeaders } from '@openpost/telemetry';
+import { applyTelemetryRequestHeaders } from '@openpost/telemetry';
 
 // Re-export schema types for convenience
 export type User = components['schemas']['UserProfile'];
@@ -25,17 +25,20 @@ export function getToken(): string | null {
 	return token;
 }
 
+export function applyAPIRequestHeaders(headers: Headers): Headers {
+	applyTelemetryRequestHeaders(headers);
+	if (token) {
+		headers.set('Authorization', `Bearer ${token}`);
+	}
+	return headers;
+}
+
 function createApiClient() {
 	const c = createClient<paths>({ baseUrl: getApiBase(), credentials: 'include' });
 	c.use({
 		async onRequest({ request }) {
 			feedbackDiagnostics.recordRequestStart(request);
-			for (const [name, value] of Object.entries(telemetryRequestHeaders())) {
-				request.headers.set(name, value);
-			}
-			if (token) {
-				request.headers.set('Authorization', `Bearer ${token}`);
-			}
+			applyAPIRequestHeaders(request.headers);
 			return request;
 		},
 		async onResponse({ request, response }) {

--- a/frontend/src/lib/components/compose-text-post.svelte
+++ b/frontend/src/lib/components/compose-text-post.svelte
@@ -6,7 +6,12 @@
 	import { beforeNavigate, goto, replaceState } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { MediaQuery, SvelteMap, SvelteSet } from 'svelte/reactivity';
-	import { client, type SocialAccount, type Workspace, getToken } from '$lib/api/client';
+	import {
+		applyAPIRequestHeaders,
+		client,
+		type SocialAccount,
+		type Workspace
+	} from '$lib/api/client';
 	import { loadCapabilityCatalog, loadWorkspaceAccounts } from '$lib/api/performance-cache';
 	import type { components } from '$lib/api/types';
 	import { getApiBase } from '$lib/stores/instance.svelte';
@@ -2749,14 +2754,13 @@
 		if (!workspaceId || missingIds.length === 0) return;
 
 		try {
-			const token = getToken();
 			const resp = await fetch(
 				`${getApiBase()}/media/metadata?workspace_id=${encodeURIComponent(
 					workspaceId
 				)}&media_ids=${encodeURIComponent(missingIds.join(','))}`,
 				{
 					credentials: 'include',
-					headers: token ? { Authorization: `Bearer ${token}` } : {}
+					headers: applyAPIRequestHeaders(new Headers())
 				}
 			);
 			if (!resp.ok) return;

--- a/frontend/src/lib/components/profile-avatar-uploader.svelte
+++ b/frontend/src/lib/components/profile-avatar-uploader.svelte
@@ -6,7 +6,7 @@
 	import CameraCapture from '$lib/components/camera-capture.svelte';
 	import InlineNotice from '$lib/components/inline-notice.svelte';
 	import { getApiBase } from '$lib/stores/instance.svelte';
-	import { getToken } from '$lib/api/client';
+	import { applyAPIRequestHeaders } from '$lib/api/client';
 	import { formatBytes } from '$lib/video/constraints';
 	import CameraIcon from '@lucide/svelte/icons/camera';
 	import ImageIcon from '@lucide/svelte/icons/image';
@@ -154,8 +154,9 @@
 			const xhr = new XMLHttpRequest();
 			xhr.open('POST', `${getApiBase()}/auth/profile/avatar`);
 			xhr.withCredentials = true;
-			const token = getToken();
-			if (token) xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+			for (const [name, value] of applyAPIRequestHeaders(new Headers())) {
+				xhr.setRequestHeader(name, value);
+			}
 			const abort = () => xhr.abort();
 			signal.addEventListener('abort', abort, { once: true });
 			const cleanup = () => signal.removeEventListener('abort', abort);

--- a/frontend/src/lib/media-upload-client.test.ts
+++ b/frontend/src/lib/media-upload-client.test.ts
@@ -24,7 +24,11 @@ describe('media-upload-client', () => {
 	});
 
 	it('sends OpenPost credentials only to instance-hosted upload targets', () => {
-		const openPostHeaders = new Headers({ Authorization: 'Bearer op_cli_secret' });
+		const openPostHeaders = new Headers({
+			Authorization: 'Bearer op_cli_secret',
+			'X-PostHog-Distinct-ID': 'browser-user-1',
+			'X-PostHog-Session-ID': 'session-1'
+		});
 		const internal = directUploadRequestPolicy(
 			'/api/v1/media/upload-session/media-1/content',
 			{ 'Content-Type': 'video/mp4' },
@@ -33,6 +37,8 @@ describe('media-upload-client', () => {
 		expect(internal.isExternal).toBe(false);
 		expect(internal.withCredentials).toBe(true);
 		expect(internal.headers.get('Authorization')).toBe('Bearer op_cli_secret');
+		expect(internal.headers.get('X-PostHog-Distinct-ID')).toBe('browser-user-1');
+		expect(internal.headers.get('X-PostHog-Session-ID')).toBe('session-1');
 
 		const external = directUploadRequestPolicy(
 			'https://bucket.example/media-1',
@@ -48,6 +54,8 @@ describe('media-upload-client', () => {
 		expect(external.withCredentials).toBe(false);
 		expect(external.headers.has('Authorization')).toBe(false);
 		expect(external.headers.has('Cookie')).toBe(false);
+		expect(external.headers.has('X-PostHog-Distinct-ID')).toBe(false);
+		expect(external.headers.has('X-PostHog-Session-ID')).toBe(false);
 		expect(external.headers.get('Content-Type')).toBe('video/mp4');
 		expect(external.headers.get('x-amz-meta-workspace')).toBe('ws-1');
 

--- a/frontend/src/lib/media-upload-client.ts
+++ b/frontend/src/lib/media-upload-client.ts
@@ -1,4 +1,4 @@
-import { getToken } from '$lib/api/client';
+import { applyAPIRequestHeaders } from '$lib/api/client';
 import type { components } from '$lib/api/types';
 import { getApiBase } from '$lib/stores/instance.svelte';
 import type { VideoConstraint, VideoPreparationProgress } from '$lib/video/types';
@@ -378,13 +378,9 @@ function apiURL(path: string): string {
 }
 
 function apiHeaders(json: boolean): Headers {
-	const headers = new Headers();
+	const headers = applyAPIRequestHeaders(new Headers());
 	if (json) {
 		headers.set('Content-Type', 'application/json');
-	}
-	const token = getToken();
-	if (token) {
-		headers.set('Authorization', `Bearer ${token}`);
 	}
 	return headers;
 }

--- a/marketing-site/src/hooks.client.ts
+++ b/marketing-site/src/hooks.client.ts
@@ -1,0 +1,7 @@
+import type { HandleClientError } from '@sveltejs/kit';
+import { captureClientException } from '@openpost/telemetry';
+
+export const handleError: HandleClientError = ({ error, status }) => {
+	if (status === 404) return;
+	captureClientException(error, { error_boundary: 'sveltekit', status });
+};

--- a/packages/telemetry/src/index.test.ts
+++ b/packages/telemetry/src/index.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { BrowserTelemetry, type BrowserTelemetryConfig } from './index';
+import {
+	applyTelemetryRequestHeaders,
+	BrowserTelemetry,
+	type BrowserTelemetryConfig
+} from './index';
 
 class FakeSDK {
 	initialized: Array<{ token: string; options: Record<string, unknown> }> = [];
@@ -9,6 +13,8 @@ class FakeSDK {
 	registered: Record<string, unknown>[] = [];
 	resetCount = 0;
 	optOutCount = 0;
+	distinctID = 'browser-user-1';
+	sessionID = 'session-1';
 
 	init(token: string, options: Record<string, unknown>) { this.initialized.push({ token, options }); }
 	capture(event: string, properties?: Record<string, unknown>) { this.events.push({ event, properties }); }
@@ -17,6 +23,8 @@ class FakeSDK {
 	register(properties: Record<string, unknown>) { this.registered.push(properties); }
 	reset() { this.resetCount += 1; }
 	opt_out_capturing() { this.optOutCount += 1; }
+	get_distinct_id() { return this.distinctID; }
+	get_session_id() { return this.sessionID; }
 }
 
 const configuredApp: BrowserTelemetryConfig = {
@@ -85,5 +93,37 @@ describe('BrowserTelemetry', () => {
 		expect(sdk.exceptions[0]?.error.message).not.toContain('secret');
 		expect(sdk.exceptions[0]?.error.message).not.toContain('user@example.com');
 		expect(sdk.exceptions[0]?.error.message).not.toContain('https://example.com');
+	});
+
+	it('redacts raw stack URLs while retaining safe source-map asset paths', () => {
+		const sdk = new FakeSDK();
+		const subject = new BrowserTelemetry(sdk, () => true);
+		subject.configure(configuredApp);
+		const error = new Error('Navigation failed');
+		error.stack = [
+			'Error: Navigation failed',
+			'    at load (https://app.openpost.social/_app/immutable/chunks/app.ABC123.js:12:3?token=secret)',
+			'    at reset (https://example.com/reset/path-secret:4:2)'
+		].join('\n');
+
+		subject.captureException(error);
+
+		const stack = sdk.exceptions[0]?.error.stack ?? '';
+		expect(stack).toContain('/_app/immutable/chunks/app.ABC123.js:12:3');
+		expect(stack).toContain('[redacted-url]');
+		expect(stack).not.toContain('app.openpost.social');
+		expect(stack).not.toContain('path-secret');
+		expect(stack).not.toContain('token=secret');
+	});
+
+	it('applies browser correlation headers to shared request transports', () => {
+		const headers = applyTelemetryRequestHeaders(new Headers({ Authorization: 'Bearer token' }), {
+			'X-PostHog-Distinct-ID': 'browser-user-1',
+			'X-PostHog-Session-ID': 'session-1'
+		});
+
+		expect(headers.get('Authorization')).toBe('Bearer token');
+		expect(headers.get('X-PostHog-Distinct-ID')).toBe('browser-user-1');
+		expect(headers.get('X-PostHog-Session-ID')).toBe('session-1');
 	});
 });

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -250,6 +250,16 @@ export function telemetryRequestHeaders(): Record<string, string> {
 	return telemetry.requestHeaders();
 }
 
+export function applyTelemetryRequestHeaders(
+	headers: Headers,
+	requestHeaders: Record<string, string> = telemetryRequestHeaders()
+): Headers {
+	for (const [name, value] of Object.entries(requestHeaders)) {
+		headers.set(name, value);
+	}
+	return headers;
+}
+
 export function installGlobalErrorCapture(): () => void {
 	if (typeof window === 'undefined') return () => undefined;
 	const onError = (event: ErrorEvent) => {
@@ -306,7 +316,24 @@ function scrubPropertyString(value: string): string {
 }
 
 function scrubStack(value: string): string {
-	return scrubSensitiveText(value).replace(/(https?:\/\/[^\s?#)\]}]+)[?#][^\s)\]}]+/gi, '$1');
+	return scrubSensitiveText(value.replace(/https?:\/\/[^\s)\]}]+/gi, scrubStackURL));
+}
+
+function scrubStackURL(value: string): string {
+	const withoutQueryOrFragment = value.replace(/[?#].*$/, '');
+	try {
+		const pathname = new URL(withoutQueryOrFragment).pathname;
+		if (
+			/^\/(?:_app\/immutable|assets)\/[A-Za-z0-9._~!$&'()*+,;=:@%/-]+\.m?js(?::\d+){0,2}$/.test(
+				pathname
+			)
+		) {
+			return pathname;
+		}
+	} catch {
+		// Invalid absolute URLs are redacted below.
+	}
+	return '[redacted-url]';
 }
 
 function scrubSensitiveText(value: string): string {


### PR DESCRIPTION
## Summary
- keep PostHog exception structure and attach backend environment and release context
- redact arbitrary absolute URLs from browser stacks while retaining static source-map paths
- propagate browser correlation through same-instance fetch and XHR transports without leaking headers to presigned uploads
- add the marketing SvelteKit client error boundary

## Review findings
- the reported exception-property overwrite was not valid for posthog-go v1.23.0 because the SDK stores exception data outside Properties
- the review exposed a real adjacent gap: exception events did not inherit default backend properties
- the other three reports were valid and are fixed here

## Validation
- go test ./internal/telemetry
- go test -tags dev ./cmd/openpost
- bun run --filter @openpost/telemetry test
- focused media-upload Vitest
- frontend-check
- marketing production build
- repository pre-push lint