### PR TITLE
fix(docs): remove legacy Umami loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove the legacy Umami loader from the documentation build now that the shared PostHog telemetry client owns that surface.
+
 ## [3.9.3] - 2026-08-11
 
 ### Fixed

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -1,277 +1,294 @@
-import { resolveDocsSocial } from '@openpost/social-images';
-import { defineConfig } from 'vitepress';
-import { postHogSourceMaps } from '../../scripts/posthog-source-maps';
+import { resolveDocsSocial } from "@openpost/social-images";
+import { defineConfig } from "vitepress";
+import { postHogSourceMaps } from "../../scripts/posthog-source-maps";
 
 // Default to root-path hosting so custom-domain deployments work without extra config.
 // Repository-path deployments (for example, GitHub Pages at /openpost/) should set OPENPOST_DOCS_BASE explicitly.
-const docsBase = process.env.OPENPOST_DOCS_BASE?.trim() || '/';
-const sourceMaps = postHogSourceMaps('docs');
+const docsBase = process.env.OPENPOST_DOCS_BASE?.trim() || "/";
+const sourceMaps = postHogSourceMaps("docs");
 
 const userDocsSidebar = [
-	{
-		text: 'Start Here',
-		collapsed: false,
-		items: [
-			{ text: 'What is OpenPost?', link: '/guide/what-is-openpost' },
-			{ text: 'Quickstart', link: '/guide/quickstart' },
-			{ text: 'Concepts', link: '/guide/concepts' },
-		],
-	},
-	{
-		text: 'Web App',
-		collapsed: false,
-		items: [
-			{ text: 'Overview', link: '/usage/' },
-			{ text: 'Agent-Assisted Publishing', link: '/usage/agent-assisted-publishing' },
-			{ text: 'Workspaces', link: '/usage/workspaces' },
-			{ text: 'Settings', link: '/usage/settings' },
-			{ text: 'Account Security', link: '/usage/account-security' },
-			{ text: 'Accounts', link: '/usage/accounts' },
-			{ text: 'Composing Posts', link: '/usage/composing-posts' },
-			{ text: 'Destination Options', link: '/usage/destination-options' },
-			{ text: 'Threads', link: '/usage/threads' },
-			{ text: 'Scheduling', link: '/usage/scheduling' },
-			{ text: 'Auto Reposts', link: '/usage/auto-reposts' },
-			{ text: 'Analytics', link: '/usage/analytics' },
-			{ text: 'Media Library', link: '/usage/media-library' },
-			{ text: 'OpenPost Studio', link: '/usage/studio' },
-		],
-	},
-	{
-		text: 'CLI',
-		collapsed: false,
-		items: [
-			{ text: 'Overview', link: '/cli/' },
-			{ text: 'Installation', link: '/cli/installation' },
-			{ text: 'Authentication', link: '/cli/authentication' },
-			{ text: 'Posting', link: '/cli/posting' },
-			{ text: 'Automation', link: '/cli/automation' },
-		],
-	},
-	{
-		text: 'MCP',
-		collapsed: false,
-		items: [{ text: 'Assistant Scheduling', link: '/mcp/' }],
-	},
-	{
-		text: 'Apps',
-		collapsed: false,
-		items: [{ text: 'Android App', link: '/installation/android' }],
-	},
-	{
-		text: 'Reference',
-		collapsed: false,
-		items: [
-			{ text: 'CLI Command Reference', link: '/reference/cli' },
-			{ text: 'Product Surface Parity', link: '/reference/surface-parity' },
-		],
-	},
+  {
+    text: "Start Here",
+    collapsed: false,
+    items: [
+      { text: "What is OpenPost?", link: "/guide/what-is-openpost" },
+      { text: "Quickstart", link: "/guide/quickstart" },
+      { text: "Concepts", link: "/guide/concepts" },
+    ],
+  },
+  {
+    text: "Web App",
+    collapsed: false,
+    items: [
+      { text: "Overview", link: "/usage/" },
+      {
+        text: "Agent-Assisted Publishing",
+        link: "/usage/agent-assisted-publishing",
+      },
+      { text: "Workspaces", link: "/usage/workspaces" },
+      { text: "Settings", link: "/usage/settings" },
+      { text: "Account Security", link: "/usage/account-security" },
+      { text: "Accounts", link: "/usage/accounts" },
+      { text: "Composing Posts", link: "/usage/composing-posts" },
+      { text: "Destination Options", link: "/usage/destination-options" },
+      { text: "Threads", link: "/usage/threads" },
+      { text: "Scheduling", link: "/usage/scheduling" },
+      { text: "Auto Reposts", link: "/usage/auto-reposts" },
+      { text: "Analytics", link: "/usage/analytics" },
+      { text: "Media Library", link: "/usage/media-library" },
+      { text: "OpenPost Studio", link: "/usage/studio" },
+    ],
+  },
+  {
+    text: "CLI",
+    collapsed: false,
+    items: [
+      { text: "Overview", link: "/cli/" },
+      { text: "Installation", link: "/cli/installation" },
+      { text: "Authentication", link: "/cli/authentication" },
+      { text: "Posting", link: "/cli/posting" },
+      { text: "Automation", link: "/cli/automation" },
+    ],
+  },
+  {
+    text: "MCP",
+    collapsed: false,
+    items: [{ text: "Assistant Scheduling", link: "/mcp/" }],
+  },
+  {
+    text: "Apps",
+    collapsed: false,
+    items: [{ text: "Android App", link: "/installation/android" }],
+  },
+  {
+    text: "Reference",
+    collapsed: false,
+    items: [
+      { text: "CLI Command Reference", link: "/reference/cli" },
+      { text: "Product Surface Parity", link: "/reference/surface-parity" },
+    ],
+  },
 ];
 
 const selfHostingSidebar = [
-	{
-		text: 'Overview',
-		collapsed: false,
-		items: [{ text: 'Start Here', link: '/self-hosting/' }],
-	},
-	{
-		text: 'Install',
-		collapsed: false,
-		items: [
-			{ text: 'Why Self-Host?', link: '/guide/why-selfhost' },
-			{ text: 'Docker Compose', link: '/installation/docker-compose' },
-			{ text: 'Single Binary', link: '/installation/binary' },
-			{ text: 'Nix Module', link: '/installation/nix-module' },
-			{ text: 'Reverse Proxy', link: '/installation/reverse-proxy' },
-			{ text: 'Build From Source', link: '/installation/build-from-source' },
-			{ text: 'Docker Run', link: '/installation/docker-run' },
-		],
-	},
-	{
-		text: 'Configure',
-		collapsed: false,
-		items: [
-			{ text: 'Overview', link: '/configuration/overview' },
-			{ text: 'Environment Variables', link: '/configuration/environment-variables' },
-			{ text: 'Product Telemetry', link: '/configuration/telemetry' },
-			{ text: 'Provider Applications', link: '/configuration/provider-applications' },
-			{ text: 'Update Status', link: '/configuration/update-status' },
-			{ text: 'User Feedback', link: '/configuration/feedback' },
-			{ text: 'Database', link: '/configuration/database' },
-			{ text: 'Media Storage', link: '/configuration/media-storage' },
-			{ text: 'CORS and URLs', link: '/configuration/cors-and-urls' },
-			{ text: 'Production Checklist', link: '/configuration/production-checklist' },
-		],
-	},
-	{
-		text: 'Providers',
-		collapsed: false,
-		items: [
-			{ text: 'Overview', link: '/providers/overview' },
-			{ text: 'Launch Verification Matrix', link: '/providers/launch-matrix' },
-			{ text: 'Supported Platforms & Limits', link: '/providers/platform-limits' },
-			{ text: 'Provider Troubleshooting', link: '/providers/troubleshooting' },
-			{ text: 'Provider Roadmap', link: '/providers/roadmap' },
-			{ text: 'X', link: '/providers/x' },
-			{ text: 'Mastodon', link: '/providers/mastodon' },
-			{ text: 'Bluesky', link: '/providers/bluesky' },
-			{ text: 'LinkedIn', link: '/providers/linkedin' },
-			{ text: 'Threads', link: '/providers/threads' },
-			{ text: 'Facebook', link: '/providers/facebook' },
-			{ text: 'Instagram', link: '/providers/instagram' },
-			{ text: 'TikTok', link: '/providers/tiktok' },
-			{ text: 'YouTube', link: '/providers/youtube' },
-			{ text: 'Discord Webhooks', link: '/providers/discord' },
-			{ text: 'Engagement, Inbox & Notifications', link: '/usage/communications' },
-		],
-	},
-	{
-		text: 'Operate',
-		collapsed: false,
-		items: [
-			{ text: 'Backups', link: '/operations/backups' },
-			{ text: 'Container Image', link: '/operations/container-image' },
-			{ text: 'Health Checks', link: '/operations/health-checks' },
-			{ text: 'Logs', link: '/operations/logs' },
-			{ text: 'Upgrades', link: '/operations/upgrades' },
-			{ text: 'Troubleshooting', link: '/operations/troubleshooting' },
-		],
-	},
-	{
-		text: 'Reference',
-		collapsed: false,
-		items: [
-			{ text: 'API', link: '/reference/api' },
-			{ text: 'Environment Variables', link: '/reference/env-vars' },
-			{ text: 'Callback URLs', link: '/reference/callback-urls' },
-			{ text: 'Docker Compose', link: '/reference/docker-compose' },
-		],
-	},
+  {
+    text: "Overview",
+    collapsed: false,
+    items: [{ text: "Start Here", link: "/self-hosting/" }],
+  },
+  {
+    text: "Install",
+    collapsed: false,
+    items: [
+      { text: "Why Self-Host?", link: "/guide/why-selfhost" },
+      { text: "Docker Compose", link: "/installation/docker-compose" },
+      { text: "Single Binary", link: "/installation/binary" },
+      { text: "Nix Module", link: "/installation/nix-module" },
+      { text: "Reverse Proxy", link: "/installation/reverse-proxy" },
+      { text: "Build From Source", link: "/installation/build-from-source" },
+      { text: "Docker Run", link: "/installation/docker-run" },
+    ],
+  },
+  {
+    text: "Configure",
+    collapsed: false,
+    items: [
+      { text: "Overview", link: "/configuration/overview" },
+      {
+        text: "Environment Variables",
+        link: "/configuration/environment-variables",
+      },
+      { text: "Product Telemetry", link: "/configuration/telemetry" },
+      {
+        text: "Provider Applications",
+        link: "/configuration/provider-applications",
+      },
+      { text: "Update Status", link: "/configuration/update-status" },
+      { text: "User Feedback", link: "/configuration/feedback" },
+      { text: "Database", link: "/configuration/database" },
+      { text: "Media Storage", link: "/configuration/media-storage" },
+      { text: "CORS and URLs", link: "/configuration/cors-and-urls" },
+      {
+        text: "Production Checklist",
+        link: "/configuration/production-checklist",
+      },
+    ],
+  },
+  {
+    text: "Providers",
+    collapsed: false,
+    items: [
+      { text: "Overview", link: "/providers/overview" },
+      { text: "Launch Verification Matrix", link: "/providers/launch-matrix" },
+      {
+        text: "Supported Platforms & Limits",
+        link: "/providers/platform-limits",
+      },
+      { text: "Provider Troubleshooting", link: "/providers/troubleshooting" },
+      { text: "Provider Roadmap", link: "/providers/roadmap" },
+      { text: "X", link: "/providers/x" },
+      { text: "Mastodon", link: "/providers/mastodon" },
+      { text: "Bluesky", link: "/providers/bluesky" },
+      { text: "LinkedIn", link: "/providers/linkedin" },
+      { text: "Threads", link: "/providers/threads" },
+      { text: "Facebook", link: "/providers/facebook" },
+      { text: "Instagram", link: "/providers/instagram" },
+      { text: "TikTok", link: "/providers/tiktok" },
+      { text: "YouTube", link: "/providers/youtube" },
+      { text: "Discord Webhooks", link: "/providers/discord" },
+      {
+        text: "Engagement, Inbox & Notifications",
+        link: "/usage/communications",
+      },
+    ],
+  },
+  {
+    text: "Operate",
+    collapsed: false,
+    items: [
+      { text: "Backups", link: "/operations/backups" },
+      { text: "Container Image", link: "/operations/container-image" },
+      { text: "Health Checks", link: "/operations/health-checks" },
+      { text: "Logs", link: "/operations/logs" },
+      { text: "Upgrades", link: "/operations/upgrades" },
+      { text: "Troubleshooting", link: "/operations/troubleshooting" },
+    ],
+  },
+  {
+    text: "Reference",
+    collapsed: false,
+    items: [
+      { text: "API", link: "/reference/api" },
+      { text: "Environment Variables", link: "/reference/env-vars" },
+      { text: "Callback URLs", link: "/reference/callback-urls" },
+      { text: "Docker Compose", link: "/reference/docker-compose" },
+    ],
+  },
 ];
 
 const developmentSidebar = [
-	{
-		text: 'Development',
-		collapsed: false,
-		items: [
-			{ text: 'Overview', link: '/development/' },
-			{ text: 'Setup', link: '/development/setup' },
-			{ text: 'Architecture', link: '/development/architecture' },
-			{ text: 'API Reference', link: '/development/api-reference' },
-			{ text: 'API Tokens', link: '/development/api-tokens' },
-			{ text: 'API Compatibility', link: '/development/compatibility-policy' },
-			{ text: 'Frontend', link: '/development/frontend' },
-			{ text: 'Image Editor Completeness', link: '/development/image-editor-completeness' },
-			{ text: 'Backend', link: '/development/backend' },
-			{ text: 'Platform Adapters', link: '/development/platform-adapters' },
-			{ text: 'Background Jobs', link: '/development/background-jobs' },
-			{ text: 'Analytics Architecture', link: '/development/analytics' },
-			{ text: 'Testing', link: '/development/testing' },
-			{ text: 'Releases and Versioning', link: '/development/releases' },
-			{ text: 'MCP And ChatGPT App', link: '/development/mcp' },
-			{ text: 'Billing And Usage', link: '/development/billing-and-usage' },
-			{ text: 'Production Architecture', link: '/development/production-readiness' },
-			{ text: 'Third-Party Notices', link: '/development/third-party-notices' },
-			{ text: 'Contributing', link: '/development/contributing' },
-		],
-	},
+  {
+    text: "Development",
+    collapsed: false,
+    items: [
+      { text: "Overview", link: "/development/" },
+      { text: "Setup", link: "/development/setup" },
+      { text: "Architecture", link: "/development/architecture" },
+      { text: "API Reference", link: "/development/api-reference" },
+      { text: "API Tokens", link: "/development/api-tokens" },
+      { text: "API Compatibility", link: "/development/compatibility-policy" },
+      { text: "Frontend", link: "/development/frontend" },
+      {
+        text: "Image Editor Completeness",
+        link: "/development/image-editor-completeness",
+      },
+      { text: "Backend", link: "/development/backend" },
+      { text: "Platform Adapters", link: "/development/platform-adapters" },
+      { text: "Background Jobs", link: "/development/background-jobs" },
+      { text: "Analytics Architecture", link: "/development/analytics" },
+      { text: "Testing", link: "/development/testing" },
+      { text: "Releases and Versioning", link: "/development/releases" },
+      { text: "MCP And ChatGPT App", link: "/development/mcp" },
+      { text: "Billing And Usage", link: "/development/billing-and-usage" },
+      {
+        text: "Production Architecture",
+        link: "/development/production-readiness",
+      },
+      { text: "Third-Party Notices", link: "/development/third-party-notices" },
+      { text: "Contributing", link: "/development/contributing" },
+    ],
+  },
 ];
 
 export default defineConfig({
-	vite: {
-		plugins: sourceMaps.plugins,
-		build: { sourcemap: sourceMaps.enabled ? 'hidden' : false },
-	},
-	title: 'OpenPost',
-	description: 'Draft, adapt, schedule, and automate social posts with the managed OpenPost app or the same self-hosted product.',
-	base: docsBase,
-	cleanUrls: true,
-	lastUpdated: true,
-	head: [
-		['link', { rel: 'icon', href: `${docsBase}assets/brand/icon.svg` }],
-		[
-			'script',
-			{
-				defer: '',
-				src: 'https://analytics.rgo.pt/script.js',
-				'data-website-id': 'fded0cc2-dbbf-4362-a0c2-494694a56621',
-			},
-		],
-	],
-	transformHead({ page, pageData }) {
-		const frontmatterDescription = pageData.frontmatter.description;
-		const social = resolveDocsSocial({
-			page,
-			title: pageData.title,
-			description:
-				typeof frontmatterDescription === 'string' ? frontmatterDescription : undefined,
-		});
-		const image = social.imageUrl;
-		return [
-			['link', { rel: 'canonical', href: social.canonical }],
-			['meta', { property: 'og:site_name', content: 'OpenPost Docs' }],
-			['meta', { property: 'og:type', content: 'website' }],
-			['meta', { property: 'og:title', content: social.socialTitle }],
-			['meta', { property: 'og:description', content: social.description }],
-			['meta', { property: 'og:url', content: social.canonical }],
-			['meta', { property: 'og:image', content: image }],
-			['meta', { property: 'og:image:secure_url', content: image }],
-			['meta', { property: 'og:image:type', content: 'image/png' }],
-			['meta', { property: 'og:image:width', content: '1200' }],
-			['meta', { property: 'og:image:height', content: '630' }],
-			['meta', { property: 'og:image:alt', content: social.imageAlt }],
-			['meta', { name: 'twitter:card', content: 'summary_large_image' }],
-			['meta', { name: 'twitter:title', content: social.socialTitle }],
-			['meta', { name: 'twitter:description', content: social.description }],
-			['meta', { name: 'twitter:image', content: image }],
-			['meta', { name: 'twitter:image:alt', content: social.imageAlt }],
-		];
-	},
-	themeConfig: {
-		logo: '/assets/brand/icon.svg',
-		nav: [
-			{ text: 'Home', link: 'https://openpost.social' },
-			{ text: 'User Docs', link: '/usage/' },
-			{ text: 'CLI', link: '/cli/' },
-			{ text: 'MCP', link: '/mcp/' },
-			{ text: 'Self-Hosting', link: '/self-hosting/' },
-			{ text: 'Providers', link: '/providers/overview' },
-			{ text: 'Developer Docs', link: '/development/' },
-			{ text: 'Community', link: 'https://discord.gg/u2QwukmY4W' },
-		],
-		socialLinks: [
-			{ icon: 'github', link: 'https://github.com/rodrgds/openpost' },
-			{ icon: 'discord', link: 'https://discord.gg/u2QwukmY4W' },
-		],
-		search: {
-			provider: 'local',
-		},
-		editLink: {
-			pattern: 'https://github.com/rodrgds/openpost/edit/main/docs-site/:path',
-			text: 'Edit this page on GitHub',
-		},
-		footer: {
-			message: 'Open source under AGPL-3.0-only.',
-			copyright: 'Copyright © 2026 OpenPost Contributors',
-		},
-		sidebar: {
-			'/installation/android': userDocsSidebar,
-			'/reference/cli': userDocsSidebar,
-			'/guide/what-is-openpost': userDocsSidebar,
-			'/guide/quickstart': userDocsSidebar,
-			'/guide/concepts': userDocsSidebar,
-			'/usage/': userDocsSidebar,
-			'/cli/': userDocsSidebar,
-			'/mcp/': userDocsSidebar,
-			'/guide/why-selfhost': selfHostingSidebar,
-			'/self-hosting/': selfHostingSidebar,
-			'/installation/': selfHostingSidebar,
-			'/configuration/': selfHostingSidebar,
-			'/providers/': selfHostingSidebar,
-			'/operations/': selfHostingSidebar,
-			'/reference/': selfHostingSidebar,
-			'/development/': developmentSidebar,
-			'/': userDocsSidebar,
-		},
-	},
+  vite: {
+    plugins: sourceMaps.plugins,
+    build: { sourcemap: sourceMaps.enabled ? "hidden" : false },
+  },
+  title: "OpenPost",
+  description:
+    "Draft, adapt, schedule, and automate social posts with the managed OpenPost app or the same self-hosted product.",
+  base: docsBase,
+  cleanUrls: true,
+  lastUpdated: true,
+  head: [["link", { rel: "icon", href: `${docsBase}assets/brand/icon.svg` }]],
+  transformHead({ page, pageData }) {
+    const frontmatterDescription = pageData.frontmatter.description;
+    const social = resolveDocsSocial({
+      page,
+      title: pageData.title,
+      description:
+        typeof frontmatterDescription === "string"
+          ? frontmatterDescription
+          : undefined,
+    });
+    const image = social.imageUrl;
+    return [
+      ["link", { rel: "canonical", href: social.canonical }],
+      ["meta", { property: "og:site_name", content: "OpenPost Docs" }],
+      ["meta", { property: "og:type", content: "website" }],
+      ["meta", { property: "og:title", content: social.socialTitle }],
+      ["meta", { property: "og:description", content: social.description }],
+      ["meta", { property: "og:url", content: social.canonical }],
+      ["meta", { property: "og:image", content: image }],
+      ["meta", { property: "og:image:secure_url", content: image }],
+      ["meta", { property: "og:image:type", content: "image/png" }],
+      ["meta", { property: "og:image:width", content: "1200" }],
+      ["meta", { property: "og:image:height", content: "630" }],
+      ["meta", { property: "og:image:alt", content: social.imageAlt }],
+      ["meta", { name: "twitter:card", content: "summary_large_image" }],
+      ["meta", { name: "twitter:title", content: social.socialTitle }],
+      ["meta", { name: "twitter:description", content: social.description }],
+      ["meta", { name: "twitter:image", content: image }],
+      ["meta", { name: "twitter:image:alt", content: social.imageAlt }],
+    ];
+  },
+  themeConfig: {
+    logo: "/assets/brand/icon.svg",
+    nav: [
+      { text: "Home", link: "https://openpost.social" },
+      { text: "User Docs", link: "/usage/" },
+      { text: "CLI", link: "/cli/" },
+      { text: "MCP", link: "/mcp/" },
+      { text: "Self-Hosting", link: "/self-hosting/" },
+      { text: "Providers", link: "/providers/overview" },
+      { text: "Developer Docs", link: "/development/" },
+      { text: "Community", link: "https://discord.gg/u2QwukmY4W" },
+    ],
+    socialLinks: [
+      { icon: "github", link: "https://github.com/rodrgds/openpost" },
+      { icon: "discord", link: "https://discord.gg/u2QwukmY4W" },
+    ],
+    search: {
+      provider: "local",
+    },
+    editLink: {
+      pattern: "https://github.com/rodrgds/openpost/edit/main/docs-site/:path",
+      text: "Edit this page on GitHub",
+    },
+    footer: {
+      message: "Open source under AGPL-3.0-only.",
+      copyright: "Copyright © 2026 OpenPost Contributors",
+    },
+    sidebar: {
+      "/installation/android": userDocsSidebar,
+      "/reference/cli": userDocsSidebar,
+      "/guide/what-is-openpost": userDocsSidebar,
+      "/guide/quickstart": userDocsSidebar,
+      "/guide/concepts": userDocsSidebar,
+      "/usage/": userDocsSidebar,
+      "/cli/": userDocsSidebar,
+      "/mcp/": userDocsSidebar,
+      "/guide/why-selfhost": selfHostingSidebar,
+      "/self-hosting/": selfHostingSidebar,
+      "/installation/": selfHostingSidebar,
+      "/configuration/": selfHostingSidebar,
+      "/providers/": selfHostingSidebar,
+      "/operations/": selfHostingSidebar,
+      "/reference/": selfHostingSidebar,
+      "/development/": developmentSidebar,
+      "/": userDocsSidebar,
+    },
+  },
 });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "check:image-policy": "bun test scripts/check-image-policy.test.mjs scripts/image-evidence.test.mjs && bun scripts/check-image-policy.mjs",
     "check:mcp-registry": "bun test scripts/check-mcp-registry.test.mjs && bun scripts/check-mcp-registry.mjs",
     "check:contracts": "bun scripts/check-contracts.mjs",
-    "check:docs": "bun test scripts/check-doc-links.test.mjs && bun scripts/check-doc-links.mjs",
+    "check:docs": "bun test scripts/check-doc-links.test.mjs scripts/check-doc-telemetry.test.mjs && bun scripts/check-doc-links.mjs",
     "check:release-version": "bun test scripts/next-release-version.test.mjs scripts/release-manifest.test.mjs scripts/release-assets.test.mjs scripts/release-lifecycle.test.mjs scripts/ci-artifacts.test.mjs scripts/release-asset-upload.test.mjs scripts/release-ci-contract.test.mjs scripts/release-surfaces.test.mjs && bun scripts/release-surfaces.mjs",
     "check:app-routes": "bun test scripts/generate-app-route-manifest.test.mjs && bun scripts/generate-app-route-manifest.mjs --check",
     "check:public-routes": "bun test scripts/check-marketing-route-manifest.test.mjs && bun scripts/check-marketing-route-manifest.mjs",

--- a/scripts/check-doc-telemetry.test.mjs
+++ b/scripts/check-doc-telemetry.test.mjs
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+
+const docsConfigPath = new URL(
+  "../docs-site/.vitepress/config.ts",
+  import.meta.url,
+);
+const docsThemePath = new URL(
+  "../docs-site/.vitepress/theme/index.ts",
+  import.meta.url,
+);
+
+describe("documentation telemetry", () => {
+  test("uses the shared PostHog client without a legacy Umami script", async () => {
+    const [config, theme] = await Promise.all([
+      readFile(docsConfigPath, "utf8"),
+      readFile(docsThemePath, "utf8"),
+    ]);
+
+    expect(config).not.toContain("analytics.rgo.pt");
+    expect(config.toLowerCase()).not.toContain("umami");
+    expect(theme).toContain("configureTelemetry");
+    expect(theme).toContain("surface: 'docs'");
+  });
+});


### PR DESCRIPTION
## Summary
- remove the remaining Umami loader from VitePress
- keep docs analytics on the shared PostHog client
- add a docs telemetry regression check

## Validation
- `bun run check:docs`
- production docs build with the PostHog EU runtime configuration
- built output contains the PostHog project token and no Umami host or identifier