### PR TITLE
fix(release): bound asset upload attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 ### Fixed
 
 - Remove the legacy Umami loader from the documentation build now that the shared PostHog telemetry client owns that surface.
+- Bound each GitHub release asset upload so a stalled transfer is terminated and retried instead of blocking image promotion and production deployment indefinitely.
 
 ## [3.9.3] - 2026-08-11
 

--- a/scripts/release-asset-upload.sh
+++ b/scripts/release-asset-upload.sh
@@ -17,6 +17,12 @@ retry_delay_seconds="${OPENPOST_RELEASE_ASSET_RETRY_DELAY_SECONDS:-3}"
   exit 2
 }
 
+upload_timeout_seconds="${OPENPOST_RELEASE_ASSET_UPLOAD_TIMEOUT_SECONDS:-600}"
+[[ "$upload_timeout_seconds" =~ ^[1-9][0-9]*$ ]] || {
+  echo "OPENPOST_RELEASE_ASSET_UPLOAD_TIMEOUT_SECONDS must be a positive integer." >&2
+  exit 2
+}
+
 expected_state=$'true\tfalse\t'"$GITHUB_REF_NAME"
 release_state=""
 
@@ -38,11 +44,35 @@ for attempt in $(seq 1 20); do
   sleep "$retry_delay_seconds"
 done
 
-for attempt in $(seq 1 5); do
-  if gh release upload "$GITHUB_REF_NAME" \
+upload_assets() {
+  gh release upload "$GITHUB_REF_NAME" \
     --repo "$GITHUB_REPOSITORY" \
     --clobber \
-    "$@"; then
+    "$@" &
+  local upload_pid=$!
+
+  (
+    for ((elapsed = 0; elapsed < upload_timeout_seconds; elapsed++)); do
+      kill -0 "$upload_pid" 2>/dev/null || exit 0
+      sleep 1
+    done
+
+    echo "Release asset upload timed out after ${upload_timeout_seconds} seconds." >&2
+    kill -TERM "$upload_pid" 2>/dev/null || exit 0
+    sleep 5
+    kill -KILL "$upload_pid" 2>/dev/null || true
+  ) &
+  local watchdog_pid=$!
+
+  local upload_status=0
+  wait "$upload_pid" || upload_status=$?
+  kill "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+  return "$upload_status"
+}
+
+for attempt in $(seq 1 5); do
+  if upload_assets "$@"; then
     exit 0
   fi
 

--- a/scripts/release-asset-upload.test.mjs
+++ b/scripts/release-asset-upload.test.mjs
@@ -75,3 +75,57 @@ exit 2
     rmSync(directory, { recursive: true, force: true });
   }
 });
+
+test("a hung asset upload is terminated and retried", () => {
+  const directory = mkdtempSync(join(tmpdir(), "openpost-release-upload-"));
+  const fakeGh = join(directory, "gh");
+  const calls = join(directory, "calls");
+
+  writeFileSync(
+    fakeGh,
+    `#!/usr/bin/env bash
+set -euo pipefail
+calls="${calls}"
+if [[ "$1 $2" == "release view" ]]; then
+  printf 'true\\tfalse\\tv9.9.9\\n'
+  exit 0
+fi
+if [[ "$1 $2" == "release upload" ]]; then
+  count="$(grep -c '^upload$' "$calls" 2>/dev/null || true)"
+  echo upload >> "$calls"
+  if [[ "$count" -lt 1 ]]; then
+    sleep 30
+  fi
+  exit 0
+fi
+exit 2
+`,
+  );
+  chmodSync(fakeGh, 0o755);
+
+  try {
+    const result = spawnSync(
+      "bash",
+      ["scripts/release-asset-upload.sh", "openpost-server-windows-amd64.exe"],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GH_TOKEN: "test-token",
+          GITHUB_REF_NAME: "v9.9.9",
+          GITHUB_REPOSITORY: "openpost/test",
+          OPENPOST_RELEASE_ASSET_RETRY_DELAY_SECONDS: "0",
+          OPENPOST_RELEASE_ASSET_UPLOAD_TIMEOUT_SECONDS: "1",
+          PATH: `${directory}:${process.env.PATH}`,
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(readFileSync(calls, "utf8").match(/^upload$/gmu)?.length, 2);
+    assert.match(result.stderr, /timed out after 1 seconds/u);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- terminate a release asset upload that stops making progress
- retry the upload through the existing bounded retry loop
- cover the hung-transfer path with a process-level regression test

## Validation
- `bun test scripts/release-asset-upload.test.mjs scripts/release-ci-contract.test.mjs scripts/release-assets.test.mjs scripts/release-lifecycle.test.mjs` (16 pass)
- `bash -n scripts/release-asset-upload.sh`
- `devenv shell -- actionlint .github/workflows/release.yml`