### PR TITLE
fix(database): create the SQLite directory before opening

### DIFF
--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/openpost/backend/internal/database/migrations"
@@ -32,6 +35,16 @@ func InitDBWithDriver(driver, dsn string) (*bun.DB, error) {
 }
 
 func initSQLiteDB(dsn string) (*bun.DB, error) {
+	// The driver does not create parent directories, and the failure surfaces
+	// as a misleading "unable to open database file: out of memory (14)" on
+	// the first statement. A container image can pre-create the directory,
+	// but a volume mounted over it masks that, so create it at open time.
+	if dir := sqliteFileDir(dsn); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("create sqlite database directory: %w", err)
+		}
+	}
+
 	// DSN e.g. "file:openpost.db?cache=shared&mode=rwc"
 	sqldb, err := sql.Open(sqliteshim.ShimName, dsn)
 	if err != nil {
@@ -59,6 +72,26 @@ func initSQLiteDB(dsn string) (*bun.DB, error) {
 	}
 
 	return db, nil
+}
+
+// sqliteFileDir returns the parent directory of the DSN's database file, or ""
+// when the DSN does not reference a file outside the working directory
+// (memory databases, bare filenames).
+func sqliteFileDir(dsn string) string {
+	path := strings.TrimPrefix(dsn, "file:")
+	if index := strings.IndexByte(path, '?'); index >= 0 {
+		if values, err := url.ParseQuery(path[index+1:]); err == nil && values.Get("mode") == "memory" {
+			return ""
+		}
+		path = path[:index]
+	}
+	if path == "" || path == ":memory:" {
+		return ""
+	}
+	if dir := filepath.Dir(path); dir != "." && dir != string(filepath.Separator) {
+		return dir
+	}
+	return ""
 }
 
 func initPostgresDB(dsn string) (*bun.DB, error) {

--- a/backend/internal/database/database_sqlite_dir_test.go
+++ b/backend/internal/database/database_sqlite_dir_test.go
@@ -1,0 +1,39 @@
+package database
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitDBCreatesMissingSQLiteDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "db", "openpost.db")
+	db, err := InitDB("file:" + path + "?cache=shared&mode=rwc")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	require.NoError(t, CreateSchema(db))
+	require.FileExists(t, path)
+}
+
+func TestSqliteFileDir(t *testing.T) {
+	cases := []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{name: "absolute file path", dsn: "file:/data/db/openpost.db?cache=shared&mode=rwc", want: "/data/db"},
+		{name: "relative nested path", dsn: "file:state/openpost.db", want: "state"},
+		{name: "bare filename", dsn: "file:openpost.db?cache=shared&mode=rwc", want: ""},
+		{name: "plain path without scheme", dsn: "/data/db/openpost.db", want: "/data/db"},
+		{name: "memory keyword", dsn: "file::memory:", want: ""},
+		{name: "memory mode", dsn: "file:test?mode=memory&cache=shared", want: ""},
+		{name: "root directory", dsn: "file:/openpost.db", want: ""},
+		{name: "empty", dsn: "", want: ""},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.want, sqliteFileDir(testCase.dsn))
+		})
+	}
+}

--- a/changes/180.md
+++ b/changes/180.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Create the SQLite database directory before opening it, so a fresh install with a volume mounted over the data path boots instead of failing with a misleading "unable to open database file" error.


### PR DESCRIPTION
Fixes #180.

`initSQLiteDB` now creates the DSN's parent directory before `sql.Open`, skipping memory DSNs (`:memory:`, `mode=memory`) and bare filenames, so a fresh install with a volume mounted over the data path boots instead of dying with `unable to open database file: out of memory (14)` (SQLITE_CANTOPEN through the driver). This matches how `OPENPOST_MEDIA_PATH` is already created at startup.

Verified:

- The issue's repro (DSN pointing into a nonexistent directory) crashed before the change and boots after it, creating the directory and the WAL files.
- New tests: `TestInitDBCreatesMissingSQLiteDirectory` (full `InitDB` + `CreateSchema` into a nested temp path) and a table test for `sqliteFileDir` covering absolute, relative, bare-filename, memory, root, and empty DSNs.
- `go test -tags dev -race ./internal/database/` green, `golangci-lint run` clean on the package.

Changelog fragment in `changes/180.md`.
