### PR TITLE
fix: add business_management scope to Facebook and Instagram adapters

### DIFF
--- a/backend/internal/platform/facebook.go
+++ b/backend/internal/platform/facebook.go
@@ -679,6 +679,7 @@ func isFacebookVideoMime(mimeType string) bool {
 
 func facebookScopes() []string {
 	return []string{
+		"business_management",
 		"pages_show_list",
 		"pages_read_engagement",
 		"pages_manage_engagement",

--- a/backend/internal/platform/instagram.go
+++ b/backend/internal/platform/instagram.go
@@ -672,6 +672,7 @@ func isInstagramVideoMime(mimeType string) bool {
 
 func instagramScopes() []string {
 	return []string{
+		"business_management",
 		"instagram_basic",
 		"instagram_content_publish",
 		"instagram_manage_comments",


### PR DESCRIPTION
## Summary

Adds the missing `business_management` scope to both Facebook and Instagram OAuth flows, allowing OpenPost to discover Pages owned by a Business Portfolio via the `/me/accounts` endpoint.

Without this scope, Meta does not return Business-Portfolio-owned Pages, which causes the OAuth callback to fail with "OpenPost could not find any Facebook Pages this profile can manage".

## Details

- Added `business_management` to `facebookScopes()`
- Added `business_management` to `instagramScopes()`

This enables support for the common use case where Pages are organized under a Business Portfolio rather than directly owned by the user profile.

## Related

Addresses #216