### PR TITLE
feat(reposts): multi-stage repost cycles & fix bluesky mention resolution

### DIFF
--- a/backend/internal/api/handlers/reposts_credential_access_test.go
+++ b/backend/internal/api/handlers/reposts_credential_access_test.go
@@ -48,6 +48,15 @@ func (*repostCredentialAdapter) Repost(
 	return platform.RepostResult{}, nil
 }
 
+func (*repostCredentialAdapter) Unrepost(
+	context.Context,
+	string,
+	string,
+	platform.UnrepostRequest,
+) error {
+	return nil
+}
+
 type repostCredentialTestServer struct {
 	echo *echo.Echo
 	db   *bun.DB

--- a/backend/internal/database/migrations/113_multi_stage_reposts.sql
+++ b/backend/internal/database/migrations/113_multi_stage_reposts.sql
@@ -1,0 +1,7 @@
+ALTER TABLE repost_executions ADD COLUMN current_stage INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE repost_executions ADD COLUMN total_stages INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE repost_executions ADD COLUMN stage_status TEXT NOT NULL DEFAULT 'pending';
+ALTER TABLE repost_executions ADD COLUMN last_repost_external_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE repost_executions ADD COLUMN stage_history_json TEXT NOT NULL DEFAULT '[]';
+
+ALTER TABLE repost_policies ADD COLUMN stages_json TEXT NOT NULL DEFAULT '[]';

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -1261,6 +1261,7 @@ type RepostPolicy struct {
 	MinViews                int64     `bun:"min_views,notnull,default:0" json:"min_views"`
 	RequirePlateau          bool      `bun:"require_plateau,notnull,default:false" json:"require_plateau"`
 	PlateauChecks           int       `bun:"plateau_checks,notnull,default:2" json:"plateau_checks"`
+	StagesJSON              string    `bun:"stages_json,notnull,default:'[]'" json:"stages_json,omitempty"`
 	CreatedByID             string    `bun:"created_by,notnull" json:"created_by"`
 	UpdatedByID             string    `bun:"updated_by,notnull" json:"updated_by"`
 	CreatedAt               time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"created_at"`
@@ -1299,27 +1300,32 @@ type RepostAccountGrant struct {
 type RepostExecution struct {
 	bun.BaseModel `bun:"table:repost_executions"`
 
-	ID               string    `bun:",pk" json:"id"`
-	WorkspaceID      string    `bun:"workspace_id,notnull" json:"workspace_id"`
-	PublicationID    string    `bun:"publication_id,notnull" json:"publication_id"`
-	RenditionID      string    `bun:"rendition_id,notnull,unique:rendition_target" json:"rendition_id"`
-	SourceAccountID  string    `bun:"source_account_id,notnull" json:"source_account_id"`
-	TargetAccountID  string    `bun:"target_account_id,notnull,unique:rendition_target" json:"target_account_id"`
-	PolicyID         string    `bun:"policy_id,nullzero" json:"policy_id,omitempty"`
-	RuleSnapshotJSON string    `bun:"rule_snapshot_json,notnull,default:'{}'" json:"rule_snapshot_json"`
-	Status           string    `bun:",notnull,default:'pending'" json:"status"`
-	EligibleAfter    time.Time `bun:"eligible_after,notnull" json:"eligible_after"`
-	DeadlineAt       time.Time `bun:"deadline_at,notnull" json:"deadline_at"`
-	NextCheckAt      time.Time `bun:"next_check_at,nullzero" json:"next_check_at"`
-	CheckCount       int       `bun:"check_count,notnull,default:0" json:"check_count"`
-	LastMetricsJSON  string    `bun:"last_metrics_json,notnull,default:'{}'" json:"last_metrics_json"`
-	ExternalID       string    `bun:"external_id,notnull,default:''" json:"external_id,omitempty"`
-	ExternalURL      string    `bun:"external_url,notnull,default:''" json:"external_url,omitempty"`
-	ErrorCode        string    `bun:"error_code,notnull,default:''" json:"error_code,omitempty"`
-	ErrorMessage     string    `bun:"error_message,notnull,default:''" json:"error_message,omitempty"`
-	CompletedAt      time.Time `bun:"completed_at,nullzero" json:"completed_at,omitempty"`
-	CreatedAt        time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"created_at"`
-	UpdatedAt        time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"updated_at"`
+	ID                   string    `bun:",pk" json:"id"`
+	WorkspaceID          string    `bun:"workspace_id,notnull" json:"workspace_id"`
+	PublicationID        string    `bun:"publication_id,notnull" json:"publication_id"`
+	RenditionID          string    `bun:"rendition_id,notnull,unique:rendition_target" json:"rendition_id"`
+	SourceAccountID      string    `bun:"source_account_id,notnull" json:"source_account_id"`
+	TargetAccountID      string    `bun:"target_account_id,notnull,unique:rendition_target" json:"target_account_id"`
+	PolicyID             string    `bun:"policy_id,nullzero" json:"policy_id,omitempty"`
+	RuleSnapshotJSON     string    `bun:"rule_snapshot_json,notnull,default:'{}'" json:"rule_snapshot_json"`
+	Status               string    `bun:",notnull,default:'pending'" json:"status"`
+	CurrentStage         int       `bun:"current_stage,notnull,default:1" json:"current_stage"`
+	TotalStages          int       `bun:"total_stages,notnull,default:1" json:"total_stages"`
+	StageStatus          string    `bun:"stage_status,notnull,default:'pending'" json:"stage_status"`
+	LastRepostExternalID string    `bun:"last_repost_external_id,notnull,default:''" json:"last_repost_external_id,omitempty"`
+	StageHistoryJSON     string    `bun:"stage_history_json,notnull,default:'[]'" json:"stage_history_json"`
+	EligibleAfter        time.Time `bun:"eligible_after,notnull" json:"eligible_after"`
+	DeadlineAt           time.Time `bun:"deadline_at,notnull" json:"deadline_at"`
+	NextCheckAt          time.Time `bun:"next_check_at,nullzero" json:"next_check_at"`
+	CheckCount           int       `bun:"check_count,notnull,default:0" json:"check_count"`
+	LastMetricsJSON      string    `bun:"last_metrics_json,notnull,default:'{}'" json:"last_metrics_json"`
+	ExternalID           string    `bun:"external_id,notnull,default:''" json:"external_id,omitempty"`
+	ExternalURL          string    `bun:"external_url,notnull,default:''" json:"external_url,omitempty"`
+	ErrorCode            string    `bun:"error_code,notnull,default:''" json:"error_code,omitempty"`
+	ErrorMessage         string    `bun:"error_message,notnull,default:''" json:"error_message,omitempty"`
+	CompletedAt          time.Time `bun:"completed_at,nullzero" json:"completed_at,omitempty"`
+	CreatedAt            time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"created_at"`
+	UpdatedAt            time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"updated_at"`
 }
 
 // PublicationSegment is an ordered canonical content unit. A post has one

--- a/backend/internal/platform/bluesky.go
+++ b/backend/internal/platform/bluesky.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -495,6 +496,48 @@ func (b *BlueskyAdapter) Repost(ctx context.Context, accessToken, targetAccountI
 	return RepostResult{ExternalID: string(externalID), ExternalURL: req.ExternalURL}, nil
 }
 
+func (b *BlueskyAdapter) Unrepost(ctx context.Context, accessToken, targetAccountID string, req UnrepostRequest) error {
+	rkey := extractBlueskyRKey(req.RepostExternalID)
+	if strings.TrimSpace(targetAccountID) == "" || rkey == "" {
+		return fmt.Errorf("bluesky unrepost requires a target account and repost id")
+	}
+	payload := map[string]interface{}{
+		"repo":       targetAccountID,
+		"collection": "app.bsky.feed.repost",
+		"rkey":       rkey,
+	}
+	_, err := DoJSON(ctx, http.MethodPost, b.pdsURL+"/xrpc/com.atproto.repo.deleteRecord", payload, map[string]string{
+		headerAuthorization: bearerPrefix + accessToken,
+	})
+	if err != nil {
+		var httpErr *HTTPError
+		if errors.As(err, &httpErr) && (httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusBadRequest) {
+			return nil
+		}
+		return fmt.Errorf("unreposting on bluesky: %w", err)
+	}
+	return nil
+}
+
+func extractBlueskyRKey(externalID string) string {
+	trimmed := strings.TrimSpace(externalID)
+	if trimmed == "" {
+		return ""
+	}
+	var ref struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &ref); err == nil && ref.URI != "" {
+		parts := strings.Split(ref.URI, "/")
+		return parts[len(parts)-1]
+	}
+	if strings.Contains(trimmed, "/") {
+		parts := strings.Split(trimmed, "/")
+		return parts[len(parts)-1]
+	}
+	return trimmed
+}
+
 func (b *BlueskyAdapter) buildPostRecord(_ string, req *PublishRequest, createdAt time.Time) (map[string]interface{}, error) {
 	record := map[string]interface{}{
 		bskyRecordTypeField: "app.bsky.feed.post",
@@ -536,10 +579,16 @@ func (b *BlueskyAdapter) resolveBlueskyComposerReferences(ctx context.Context, a
 	}
 	mentions := map[string]string{}
 	for _, match := range blueskyMentionPattern.FindAllStringSubmatch(req.Content, -1) {
-		if len(match) < 2 {
+		if len(match) == 0 || match[0] == "" {
 			continue
 		}
-		handle := strings.ToLower(strings.TrimSpace(match[1]))
+		handle := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(match[0]), "@"))
+		if handle == "" {
+			continue
+		}
+		if _, exists := mentions[handle]; exists {
+			continue
+		}
 		did, err := b.resolveBlueskyHandle(ctx, accessToken, handle)
 		if err != nil {
 			return err
@@ -661,7 +710,7 @@ func copyPlatformSettings(source map[string]interface{}) map[string]interface{} 
 
 var (
 	blueskyURLPattern     = regexp.MustCompile(`https?://[-A-Za-z0-9@:%._+~#=]{1,256}\.[A-Za-z0-9()]{1,6}\b[-A-Za-z0-9()@:%_+.~#?&/=]*`)
-	blueskyMentionPattern = regexp.MustCompile(`@([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?`)
+	blueskyMentionPattern = regexp.MustCompile(`@((?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)`)
 	blueskyTagPattern     = regexp.MustCompile(`#[A-Za-z0-9_]+`)
 )
 

--- a/backend/internal/platform/bluesky_test.go
+++ b/backend/internal/platform/bluesky_test.go
@@ -1,6 +1,11 @@
 package platform
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -112,3 +117,118 @@ func requireFacet(t *testing.T, facets []map[string]interface{}, byteStart, byte
 	}
 	require.Failf(t, "facet not found", "missing facet %d-%d in %#v", byteStart, byteEnd, facets)
 }
+
+func TestExtractBlueskyRKey(t *testing.T) {
+	// JSON with URI
+	require.Equal(t, "3lb7v4d3t2c2f", extractBlueskyRKey(`{"uri":"at://did:plc:123/app.bsky.feed.repost/3lb7v4d3t2c2f","cid":"bafy123"}`))
+	// Raw AT URI
+	require.Equal(t, "3lb7v4d3t2c2f", extractBlueskyRKey("at://did:plc:123/app.bsky.feed.repost/3lb7v4d3t2c2f"))
+	// Raw RKey
+	require.Equal(t, "3lb7v4d3t2c2f", extractBlueskyRKey("3lb7v4d3t2c2f"))
+	// Empty
+	require.Equal(t, "", extractBlueskyRKey(""))
+}
+
+func TestBlueskyUnrepost(t *testing.T) {
+	originalClient := httpClient
+	defer func() { httpClient = originalClient }()
+
+	called := false
+	httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost || req.URL.String() != "https://bsky.social/xrpc/com.atproto.repo.deleteRecord" {
+			t.Fatalf("unexpected request %s %s", req.Method, req.URL.String())
+		}
+		if req.Header.Get(headerAuthorization) != "Bearer bsky-token" {
+			t.Fatalf("unexpected auth header %q", req.Header.Get(headerAuthorization))
+		}
+		var payload map[string]string
+		body, _ := io.ReadAll(req.Body)
+		_ = json.Unmarshal(body, &payload)
+		require.Equal(t, "did:plc:user1", payload["repo"])
+		require.Equal(t, "app.bsky.feed.repost", payload["collection"])
+		require.Equal(t, "3lb7v4d3t2c2f", payload["rkey"])
+		called = true
+		return jsonResponse(req, `{}`), nil
+	})}
+
+	adapter := NewBlueskyAdapter("https://bsky.social")
+	err := adapter.Unrepost(context.Background(), "bsky-token", "did:plc:user1", UnrepostRequest{
+		RepostExternalID: `{"uri":"at://did:plc:user1/app.bsky.feed.repost/3lb7v4d3t2c2f","cid":"bafy123"}`,
+	})
+	require.NoError(t, err)
+	require.True(t, called)
+}
+
+func TestBlueskyUnrepostIdempotent400And404(t *testing.T) {
+	originalClient := httpClient
+	defer func() { httpClient = originalClient }()
+
+	for _, status := range []int{http.StatusBadRequest, http.StatusNotFound} {
+		httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: status,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":"RecordNotFound"}`)),
+				Request:    req,
+			}, nil
+		})}
+
+		adapter := NewBlueskyAdapter("https://bsky.social")
+		err := adapter.Unrepost(context.Background(), "bsky-token", "did:plc:user1", UnrepostRequest{
+			RepostExternalID: "3lb7v4d3t2c2f",
+		})
+		require.NoError(t, err)
+	}
+}
+
+func TestResolveBlueskyComposerReferencesMultiSegmentHandles(t *testing.T) {
+	originalClient := httpClient
+	defer func() { httpClient = originalClient }()
+
+	resolvedHandles := []string{}
+	httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if strings.Contains(req.URL.Path, "com.atproto.identity.resolveHandle") {
+			handle := req.URL.Query().Get("handle")
+			resolvedHandles = append(resolvedHandles, handle)
+			if handle == "mercurykitsune.bsky.social" {
+				return jsonResponse(req, `{"did":"did:plc:mercury123"}`), nil
+			}
+			if handle == "anielde.bsky.social" {
+				return jsonResponse(req, `{"did":"did:plc:anielde123"}`), nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":"InvalidRequest","message":"Unable to resolve handle"}`)),
+				Request:    req,
+			}, nil
+		}
+		return jsonResponse(req, `{}`), nil
+	})}
+
+	adapter := NewBlueskyAdapter("https://bsky.social")
+	req := &PublishRequest{
+		Content:  "👅💦 ... @mercurykitsune.bsky.social doing the work of gods with @anielde.bsky.social 👌",
+		Settings: map[string]interface{}{},
+	}
+
+	err := adapter.resolveBlueskyComposerReferences(context.Background(), "test-token", req)
+	require.NoError(t, err)
+
+	require.Contains(t, resolvedHandles, "mercurykitsune.bsky.social")
+	require.Contains(t, resolvedHandles, "anielde.bsky.social")
+	require.NotContains(t, resolvedHandles, "bsky.")
+
+	rawDIDs, ok := req.Settings["mention_dids"].(string)
+	require.True(t, ok)
+	var mentionMap map[string]string
+	require.NoError(t, json.Unmarshal([]byte(rawDIDs), &mentionMap))
+	require.Equal(t, "did:plc:mercury123", mentionMap["mercurykitsune.bsky.social"])
+	require.Equal(t, "did:plc:anielde123", mentionMap["anielde.bsky.social"])
+
+	// Test facet generation
+	facets := buildBlueskyFacets(req.Content, req.Settings)
+	require.Len(t, facets, 2)
+}
+
+

--- a/backend/internal/platform/linkedin.go
+++ b/backend/internal/platform/linkedin.go
@@ -591,6 +591,26 @@ func (l *LinkedInAdapter) Repost(ctx context.Context, accessToken, targetAccount
 	return RepostResult{ExternalID: headers.Get("x-restli-id"), ExternalURL: req.ExternalURL}, nil
 }
 
+func (l *LinkedInAdapter) Unrepost(ctx context.Context, accessToken, targetAccountID string, req UnrepostRequest) error {
+	urn := strings.TrimSpace(req.RepostExternalID)
+	if urn == "" {
+		urn = strings.TrimSpace(req.SourceExternalID)
+	}
+	if urn == "" {
+		return fmt.Errorf("linkedin unrepost requires a repost id")
+	}
+	endpoint := "https://api.linkedin.com/rest/posts/" + url.PathEscape(urn)
+	if _, err := DoRequest(ctx, http.MethodDelete, endpoint, nil, linkedinHeaders(accessToken, linkedInAPIVersion())); err != nil {
+		var httpErr *HTTPError
+		if errors.As(err, &httpErr) && (httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusGone) {
+			return nil
+		}
+		return fmt.Errorf("unreposting on linkedin: %w", err)
+	}
+	return nil
+}
+
+
 //nolint:gocyclo
 func (l *LinkedInAdapter) createPost(ctx context.Context, accessToken, authorURN, apiVersion string, req *PublishRequest) (string, error) {
 	visibility := firstNonEmptyString(settingString(req.Settings, "visibility"), "PUBLIC")

--- a/backend/internal/platform/linkedin_test.go
+++ b/backend/internal/platform/linkedin_test.go
@@ -270,3 +270,54 @@ func TestLinkedInHideCommentUnsupported(t *testing.T) {
 		t.Fatalf("expected unsupported comment action, got %v", err)
 	}
 }
+
+func TestLinkedInUnrepost(t *testing.T) {
+	originalClient := httpClient
+	defer func() { httpClient = originalClient }()
+
+	called := false
+	httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodDelete || req.URL.String() != "https://api.linkedin.com/rest/posts/urn:li:share:12345" {
+			t.Fatalf("unexpected request %s %s", req.Method, req.URL.String())
+		}
+		if req.Header.Get(headerAuthorization) != "Bearer li-token" {
+			t.Fatalf("unexpected auth header %q", req.Header.Get(headerAuthorization))
+		}
+		called = true
+		return jsonResponseWithStatus(req, http.StatusNoContent, ""), nil
+	})}
+
+	adapter := NewLinkedInAdapter("", "", "", false)
+	err := adapter.Unrepost(context.Background(), "li-token", "target-acct", UnrepostRequest{
+		RepostExternalID: "urn:li:share:12345",
+	})
+	if err != nil {
+		t.Fatalf("Unrepost returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected delete request to be made")
+	}
+}
+
+func TestLinkedInUnrepostIdempotent404(t *testing.T) {
+	originalClient := httpClient
+	defer func() { httpClient = originalClient }()
+
+	httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"error":"Not Found"}`)),
+			Request:    req,
+		}, nil
+	})}
+
+	adapter := NewLinkedInAdapter("", "", "", false)
+	err := adapter.Unrepost(context.Background(), "li-token", "target-acct", UnrepostRequest{
+		RepostExternalID: "urn:li:share:12345",
+	})
+	if err != nil {
+		t.Fatalf("expected nil for 404, got: %v", err)
+	}
+}
+

--- a/backend/internal/platform/mastodon.go
+++ b/backend/internal/platform/mastodon.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -357,6 +358,45 @@ func (m *MastodonAdapter) Repost(ctx context.Context, accessToken, _ string, req
 		return RepostResult{}, fmt.Errorf("decoding mastodon repost: %w", err)
 	}
 	return RepostResult{ExternalID: result.ID, ExternalURL: result.URL}, nil
+}
+
+func (m *MastodonAdapter) Unrepost(ctx context.Context, accessToken, _ string, req UnrepostRequest) error {
+	statusID := strings.TrimSpace(req.RepostExternalID)
+	if statusID == "" {
+		statusID = strings.TrimSpace(req.SourceExternalID)
+		if req.SourceInstanceURL != "" && strings.TrimRight(req.SourceInstanceURL, "/") != strings.TrimRight(m.instanceURL, "/") {
+			if strings.TrimSpace(req.SourceExternalURL) != "" {
+				endpoint := m.instanceURL + "/api/v2/search?q=" + url.QueryEscape(req.SourceExternalURL) + "&type=statuses&resolve=true&limit=1"
+				body, err := DoRequest(ctx, http.MethodGet, endpoint, nil, map[string]string{
+					headerAuthorization: bearerPrefix + accessToken,
+				})
+				if err == nil {
+					var result struct {
+						Statuses []struct {
+							ID string `json:"id"`
+						} `json:"statuses"`
+					}
+					if json.Unmarshal(body, &result) == nil && len(result.Statuses) > 0 {
+						statusID = result.Statuses[0].ID
+					}
+				}
+			}
+		}
+	}
+	if statusID == "" {
+		return fmt.Errorf("mastodon unrepost requires a status id")
+	}
+	_, err := DoRequest(ctx, http.MethodPost, m.instanceURL+"/api/v1/statuses/"+url.PathEscape(statusID)+"/unreblog", nil, map[string]string{
+		headerAuthorization: bearerPrefix + accessToken,
+	})
+	if err != nil {
+		var httpErr *HTTPError
+		if errors.As(err, &httpErr) && (httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusGone) {
+			return nil
+		}
+		return fmt.Errorf("unreposting on mastodon: %w", err)
+	}
+	return nil
 }
 
 func buildMastodonStatusForm(req *PublishRequest) (url.Values, error) {

--- a/backend/internal/platform/mastodon_test.go
+++ b/backend/internal/platform/mastodon_test.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestMastodonResolveAccountPublishingCapabilitiesReadsInstanceVideoLimits(t *testing.T) {
@@ -133,3 +135,48 @@ func assertFormValue(t *testing.T, values url.Values, key, want string) {
 		t.Fatalf("expected %s=%q, got %q in %#v", key, want, got, values)
 	}
 }
+
+func TestMastodonUnrepost(t *testing.T) {
+	originalClient := httpClient
+	defer func() { httpClient = originalClient }()
+
+	called := false
+	httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost || req.URL.String() != "https://mastodon.example/api/v1/statuses/12345/unreblog" {
+			t.Fatalf("unexpected request %s %s", req.Method, req.URL.String())
+		}
+		if req.Header.Get(headerAuthorization) != "Bearer access-token" {
+			t.Fatalf("unexpected auth header %q", req.Header.Get(headerAuthorization))
+		}
+		called = true
+		return jsonResponse(req, `{"id":"12345"}`), nil
+	})}
+
+	adapter := NewMastodonAdapter("client-id", "client-secret", "https://app.example/callback", "https://mastodon.example")
+	err := adapter.Unrepost(context.Background(), "access-token", "acct-1", UnrepostRequest{
+		RepostExternalID: "12345",
+	})
+	require.NoError(t, err)
+	require.True(t, called)
+}
+
+func TestMastodonUnrepostIdempotent404(t *testing.T) {
+	originalClient := httpClient
+	defer func() { httpClient = originalClient }()
+
+	httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"error":"Record not found"}`)),
+			Request:    req,
+		}, nil
+	})}
+
+	adapter := NewMastodonAdapter("client-id", "client-secret", "https://app.example/callback", "https://mastodon.example")
+	err := adapter.Unrepost(context.Background(), "access-token", "acct-1", UnrepostRequest{
+		RepostExternalID: "12345",
+	})
+	require.NoError(t, err)
+}
+

--- a/backend/internal/platform/repost.go
+++ b/backend/internal/platform/repost.go
@@ -16,8 +16,18 @@ type RepostResult struct {
 	ExternalURL string
 }
 
+type UnrepostRequest struct {
+	SourceAccountID   string
+	SourceInstanceURL string
+	SourceExternalID  string
+	SourceExternalURL string
+	RepostExternalID  string
+}
+
 // RepostAdapter is an optional capability. Keeping it out of Adapter lets
 // providers without a native repost API remain valid publishing adapters.
 type RepostAdapter interface {
 	Repost(ctx context.Context, accessToken, targetAccountID string, req RepostRequest) (RepostResult, error)
+	Unrepost(ctx context.Context, accessToken, targetAccountID string, req UnrepostRequest) error
 }
+

--- a/backend/internal/platform/x.go
+++ b/backend/internal/platform/x.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -742,6 +743,34 @@ func (x *XAdapter) Repost(ctx context.Context, accessToken, targetAccountID stri
 	}
 	return RepostResult{ExternalID: req.ExternalID, ExternalURL: req.ExternalURL}, nil
 }
+
+func (x *XAdapter) Unrepost(ctx context.Context, accessToken, targetAccountID string, req UnrepostRequest) error {
+	sourceTweetID := strings.TrimSpace(req.SourceExternalID)
+	if sourceTweetID == "" {
+		sourceTweetID = strings.TrimSpace(req.RepostExternalID)
+	}
+	if strings.TrimSpace(targetAccountID) == "" || sourceTweetID == "" {
+		return fmt.Errorf("x unrepost requires a target account and source post id")
+	}
+	endpoint := x.apiURL("/2/users/" + url.PathEscape(targetAccountID) + "/retweets/" + url.PathEscape(sourceTweetID))
+	_, err := x.doSignedRequest(
+		ctx,
+		accessToken,
+		http.MethodDelete,
+		endpoint,
+		nil,
+		nil,
+	)
+	if err != nil {
+		var httpErr *HTTPError
+		if errors.As(err, &httpErr) && (httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusGone) {
+			return nil
+		}
+		return fmt.Errorf("unreposting on X: %w", err)
+	}
+	return nil
+}
+
 
 func buildXTweetPayload(req *PublishRequest) (map[string]interface{}, error) {
 	payload := map[string]interface{}{

--- a/backend/internal/platform/x_test.go
+++ b/backend/internal/platform/x_test.go
@@ -344,3 +344,51 @@ func TestXMediaProcessingFailureIsTerminal(t *testing.T) {
 		t.Fatalf("expected terminal media failure, got %q, %v", classification, ok)
 	}
 }
+
+func TestXUnrepost(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodDelete && req.URL.Path == "/2/users/target-user/retweets/tweet-123" {
+			called = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"retweeted":false}}`))
+			return
+		}
+		http.NotFound(w, req)
+	}))
+	defer server.Close()
+
+	adapter := NewXAdapter("consumer-key", "consumer-secret", "")
+	defer close(adapter.cleanupDone)
+	adapter.apiBaseURL = server.URL
+
+	err := adapter.Unrepost(t.Context(), "token|secret", "target-user", UnrepostRequest{
+		SourceExternalID: "tweet-123",
+	})
+	if err != nil {
+		t.Fatalf("Unrepost returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected delete retweet request to be made")
+	}
+}
+
+func TestXUnrepostIdempotent404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"Could not find tweet"}]}`))
+	}))
+	defer server.Close()
+
+	adapter := NewXAdapter("consumer-key", "consumer-secret", "")
+	defer close(adapter.cleanupDone)
+	adapter.apiBaseURL = server.URL
+
+	err := adapter.Unrepost(t.Context(), "token|secret", "target-user", UnrepostRequest{
+		SourceExternalID: "tweet-123",
+	})
+	if err != nil {
+		t.Fatalf("expected nil on 404, got: %v", err)
+	}
+}
+

--- a/backend/internal/services/growth/jobs.go
+++ b/backend/internal/services/growth/jobs.go
@@ -106,7 +106,7 @@ func (s *Service) handleDiscovery(ctx context.Context, p growthDiscoveryPayload)
 			if err != nil {
 				return err
 			}
-			reloaded, reloadErr := s.loadSyncState(txCtx, p.SocialAccountID)
+			reloaded, reloadErr := s.loadSyncStateDB(txCtx, tx, p.SocialAccountID)
 			if reloadErr != nil {
 				return reloadErr
 			}
@@ -520,9 +520,14 @@ func normalizeCandidate(c platform.GrowthCandidate) platform.GrowthCandidate {
 }
 
 func (s *Service) loadSyncState(ctx context.Context, socialAccountID string) (*models.GrowthSyncState, error) {
+	return s.loadSyncStateDB(ctx, s.db, socialAccountID)
+}
+
+func (s *Service) loadSyncStateDB(ctx context.Context, db bun.IDB, socialAccountID string) (*models.GrowthSyncState, error) {
 	var state models.GrowthSyncState
-	if err := s.db.NewSelect().Model(&state).Where("social_account_id = ?", socialAccountID).Scan(ctx); err != nil {
+	if err := db.NewSelect().Model(&state).Where("social_account_id = ?", socialAccountID).Scan(ctx); err != nil {
 		return nil, err
 	}
 	return &state, nil
 }
+

--- a/backend/internal/services/growth/service_test.go
+++ b/backend/internal/services/growth/service_test.go
@@ -565,3 +565,40 @@ func TestJobPayloadValidation(t *testing.T) {
 	_, err = decodeFollowPayload(`{}`)
 	require.Error(t, err)
 }
+
+func TestDiscoveryInitialSyncStateSingleConnection(t *testing.T) {
+	db := growthTestDB(t)
+	db.DB.SetMaxOpenConns(1)
+	seedGrowthWorkspace(t, db, "ws-1", "user-1", models.WorkspaceRoleEditor)
+	now := time.Now().UTC()
+	_, err := db.NewInsert().Model(&models.SocialAccount{
+		ID: "acc-1", WorkspaceID: "ws-1", Platform: "bluesky", AccountID: "did:plc:viewer",
+		IsActive: true, AccessTokenEnc: []byte("tok"), CreatedAt: now,
+	}).Exec(t.Context())
+	require.NoError(t, err)
+
+	adapter := &fakeGrowthAdapter{
+		discover: func(_ context.Context, _ platform.GrowthDiscoveryInput) ([]platform.GrowthCandidate, error) {
+			return []platform.GrowthCandidate{
+				{RemoteID: "remote-1", Handle: "alice", DisplayName: "Alice", FollowersCount: 10, FollowingCount: 5, MutualCount: 2},
+			}, nil
+		},
+	}
+	svc := NewService(db, staticTokenSource{}, nil)
+	svc.SetFeatureGate(alwaysEnabledGate{})
+	svc.SetProvider("bluesky", adapter)
+
+	// Note: growth_sync_states row does not exist yet.
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	payload := `{"workspace_id":"ws-1","social_account_id":"acc-1","actor_user_id":"user-1"}`
+	err = svc.HandleJob(ctx, jobregistry.TypeGrowthDiscovery, payload)
+	require.NoError(t, err)
+
+	state, err := svc.loadSyncState(t.Context(), "acc-1")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Equal(t, models.GrowthSyncStatusOK, state.Status)
+}
+

--- a/backend/internal/services/reposts/runtime.go
+++ b/backend/internal/services/reposts/runtime.go
@@ -225,26 +225,36 @@ func (s *Service) createExecution(
 		return err
 	}
 	now := time.Now().UTC()
-	eligibleAfter := publishedAt.Add(time.Duration(rule.DelaySeconds) * time.Second)
+	totalStages := len(rule.Stages)
+	if totalStages == 0 {
+		totalStages = 1
+	}
+	firstStageDelay := rule.Stages[0].DelaySeconds
+	eligibleAfter := publishedAt.Add(time.Duration(firstStageDelay) * time.Second)
 	deadline := publishedAt.Add(time.Duration(rule.EvaluationWindowSeconds) * time.Second)
 	if deadline.Before(now) {
 		return nil
 	}
 	execution := &models.RepostExecution{
-		ID:               uuid.NewString(),
-		WorkspaceID:      publication.WorkspaceID,
-		PublicationID:    publication.ID,
-		RenditionID:      rendition.ID,
-		SourceAccountID:  source.ID,
-		TargetAccountID:  target.ID,
-		PolicyID:         policyID,
-		RuleSnapshotJSON: string(snapshot),
-		Status:           StatusPending,
-		EligibleAfter:    eligibleAfter,
-		DeadlineAt:       deadline,
-		NextCheckAt:      maxTime(now, eligibleAfter),
-		CreatedAt:        now,
-		UpdatedAt:        now,
+		ID:                   uuid.NewString(),
+		WorkspaceID:          publication.WorkspaceID,
+		PublicationID:        publication.ID,
+		RenditionID:          rendition.ID,
+		SourceAccountID:      source.ID,
+		TargetAccountID:      target.ID,
+		PolicyID:             policyID,
+		RuleSnapshotJSON:     string(snapshot),
+		Status:               StatusPending,
+		CurrentStage:         1,
+		TotalStages:          totalStages,
+		StageStatus:          StatusPending,
+		LastRepostExternalID: "",
+		StageHistoryJSON:     "[]",
+		EligibleAfter:        eligibleAfter,
+		DeadlineAt:           deadline,
+		NextCheckAt:          maxTime(now, eligibleAfter),
+		CreatedAt:            now,
+		UpdatedAt:            now,
 	}
 	result, err := s.db.NewInsert().Model(execution).On("CONFLICT (rendition_id, target_account_id) DO NOTHING").Exec(ctx)
 	if err != nil {
@@ -261,6 +271,7 @@ func (s *Service) createExecution(
 		"target_account_id": target.ID,
 		"eligible_after":    eligibleAfter.Format(time.RFC3339),
 		"deadline_at":       deadline.Format(time.RFC3339),
+		"total_stages":      totalStages,
 	})
 	return nil
 }
@@ -300,9 +311,16 @@ func (s *Service) evaluate(ctx context.Context, executionID string) error {
 	execution.UpdatedAt = now
 	if eligible {
 		execution.Status = StatusReady
+		execution.StageStatus = StatusReady
 		execution.NextCheckAt = now
-		if _, err := s.db.NewUpdate().Model(execution).Column("status", "next_check_at", "check_count", "last_metrics_json", "updated_at").Where("id = ? AND status = ?", execution.ID, StatusPending).Exec(ctx); err != nil {
+		res, err := s.db.NewUpdate().Model(execution).
+			Column("status", "stage_status", "next_check_at", "check_count", "last_metrics_json", "updated_at").
+			Where("id = ? AND status = ?", execution.ID, StatusPending).Exec(ctx)
+		if err != nil {
 			return err
+		}
+		if rows, _ := res.RowsAffected(); rows == 0 {
+			return nil
 		}
 		return s.enqueueExecution(ctx, execution.ID, JobTypeExecute, now)
 	}
@@ -317,7 +335,7 @@ func (s *Service) evaluate(ctx context.Context, executionID string) error {
 }
 
 func (s *Service) execute(ctx context.Context, executionID string) error {
-	execution, _, err := s.loadExecutionRule(ctx, executionID, StatusReady)
+	execution, rule, err := s.loadExecutionRule(ctx, executionID, StatusReady)
 	if err != nil || execution == nil {
 		return err
 	}
@@ -346,29 +364,146 @@ func (s *Service) execute(ctx context.Context, executionID string) error {
 		s.markExecutionFailed(ctx, execution, "authentication_failed", "The target account needs to be reconnected.")
 		return fmt.Errorf("repost target authentication: %w", err)
 	}
+
+	currentStageIdx := execution.CurrentStage - 1
+	if currentStageIdx < 0 {
+		currentStageIdx = 0
+	}
+	var currentStage RepostStage
+	if currentStageIdx < len(rule.Stages) {
+		currentStage = rule.Stages[currentStageIdx]
+	} else {
+		currentStage = RepostStage{Stage: execution.CurrentStage, DelaySeconds: rule.DelaySeconds}
+	}
+
+	var history []StageHistoryEntry
+	if execution.StageHistoryJSON != "" && execution.StageHistoryJSON != "[]" {
+		_ = json.Unmarshal([]byte(execution.StageHistoryJSON), &history)
+	}
+
+	if execution.CurrentStage >= 2 && currentStage.UnrepostPrevious {
+		lastRepostID := strings.TrimSpace(execution.LastRepostExternalID)
+		if lastRepostID == "" {
+			lastRepostID = strings.TrimSpace(execution.ExternalID)
+		}
+		unrepostReq := platform.UnrepostRequest{
+			SourceAccountID:   source.AccountID,
+			SourceInstanceURL: source.InstanceURL,
+			SourceExternalID:  rendition.ExternalID,
+			SourceExternalURL: repostSourceURL(source, rendition),
+			RepostExternalID:  lastRepostID,
+		}
+		if unrepostErr := adapter.Unrepost(ctx, token, target.AccountID, unrepostReq); unrepostErr != nil {
+			retryNow := time.Now().UTC()
+			backoffTime := retryNow.Add(5 * time.Minute)
+			execution.NextCheckAt = backoffTime
+			execution.StageStatus = StatusPending
+			execution.Status = StatusPending
+			execution.UpdatedAt = retryNow
+			_, _ = s.db.NewUpdate().Model(execution).
+				Column("status", "stage_status", "next_check_at", "updated_at").
+				Where("id = ?", execution.ID).Exec(ctx)
+			_ = s.enqueueExecution(ctx, execution.ID, JobTypeEvaluate, backoffTime)
+			return fmt.Errorf("unreposting previous stage: %w", unrepostErr)
+		}
+		unrepostedAt := time.Now().UTC()
+		if len(history) > 0 {
+			history[len(history)-1].UnrepostedAt = unrepostedAt
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(1 * time.Second):
+		}
+	}
+
 	result, err := s.executeRepostWrite(ctx, *execution, source, target, rendition, adapter, token)
 	if err != nil {
 		s.markExecutionFailed(ctx, execution, "provider_write_failed", "The provider write failed. OpenPost did not retry because the result may be ambiguous.")
 		return err
 	}
+
 	now := time.Now().UTC()
-	execution.Status = StatusSucceeded
+
+	history = append(history, StageHistoryEntry{
+		Stage:            execution.CurrentStage,
+		DelaySeconds:     currentStage.DelaySeconds,
+		UnrepostPrevious: currentStage.UnrepostPrevious,
+		RepostExternalID: result.ExternalID,
+		ExternalURL:      result.ExternalURL,
+		ExecutedAt:       now,
+	})
+	historyJSON, _ := json.Marshal(history)
+	execution.StageHistoryJSON = string(historyJSON)
+	execution.LastRepostExternalID = result.ExternalID
 	execution.ExternalID = result.ExternalID
 	execution.ExternalURL = result.ExternalURL
 	execution.ErrorCode = ""
 	execution.ErrorMessage = ""
+	execution.UpdatedAt = now
+
+	var publication models.Publication
+	_ = s.db.NewSelect().Model(&publication).Where("id = ?", execution.PublicationID).Scan(ctx)
+	publishedAt := publication.ActualRunAt
+	if publishedAt.IsZero() {
+		publishedAt = rendition.UpdatedAt
+	}
+	if publishedAt.IsZero() {
+		publishedAt = execution.CreatedAt
+	}
+
+	if execution.CurrentStage < execution.TotalStages && execution.CurrentStage < len(rule.Stages) {
+		nextStageIdx := execution.CurrentStage
+		nextStage := rule.Stages[nextStageIdx]
+		nextEligibleAfter := publishedAt.Add(time.Duration(nextStage.DelaySeconds) * time.Second)
+
+		execution.CurrentStage++
+		execution.Status = StatusPending
+		execution.StageStatus = StatusPending
+		execution.EligibleAfter = nextEligibleAfter
+		execution.NextCheckAt = maxTime(now, nextEligibleAfter)
+
+		res, err := s.db.NewUpdate().Model(execution).
+			Column("current_stage", "status", "stage_status", "eligible_after", "next_check_at", "last_repost_external_id", "external_id", "external_url", "stage_history_json", "error_code", "error_message", "updated_at").
+			Where("id = ? AND status = ?", execution.ID, StatusReady).Exec(ctx)
+		if err != nil {
+			return err
+		}
+		if rows, _ := res.RowsAffected(); rows == 0 {
+			return nil
+		}
+		if err := s.enqueueExecution(ctx, execution.ID, JobTypeEvaluate, execution.NextCheckAt); err != nil {
+			return err
+		}
+		s.recordEvent(ctx, *execution, lifecycle.StatusInfo, fmt.Sprintf("stage %d reposted; stage %d scheduled", execution.CurrentStage-1, execution.CurrentStage), map[string]any{
+			"target_account_id": target.ID,
+			"external_id":       result.ExternalID,
+			"external_url":      result.ExternalURL,
+			"current_stage":     execution.CurrentStage,
+			"total_stages":      execution.TotalStages,
+			"next_check_at":     execution.NextCheckAt.Format(time.RFC3339),
+		})
+		return nil
+	}
+
+	execution.Status = StatusSucceeded
+	execution.StageStatus = StatusSucceeded
 	execution.NextCheckAt = time.Time{}
 	execution.CompletedAt = now
-	execution.UpdatedAt = now
-	if _, err := s.db.NewUpdate().Model(execution).
-		Column("status", "external_id", "external_url", "error_code", "error_message", "next_check_at", "completed_at", "updated_at").
-		Where("id = ? AND status = ?", execution.ID, StatusReady).Exec(ctx); err != nil {
+	res, err := s.db.NewUpdate().Model(execution).
+		Column("status", "stage_status", "last_repost_external_id", "external_id", "external_url", "stage_history_json", "error_code", "error_message", "next_check_at", "completed_at", "updated_at").
+		Where("id = ? AND status = ?", execution.ID, StatusReady).Exec(ctx)
+	if err != nil {
 		return err
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return nil
 	}
 	s.recordEvent(ctx, *execution, lifecycle.StatusSucceeded, "post reposted", map[string]any{
 		"target_account_id": target.ID,
 		"external_id":       result.ExternalID,
 		"external_url":      result.ExternalURL,
+		"total_stages":      execution.TotalStages,
 	})
 	return nil
 }
@@ -385,13 +520,26 @@ func (s *Service) executeRepostWrite(
 		SourceAccountID: source.AccountID, SourceInstanceURL: source.InstanceURL,
 		ExternalID: rendition.ExternalID, ExternalURL: repostSourceURL(source, rendition),
 	}
-	fingerprint, err := providerwrite.Fingerprint("provider-repost-v1", request)
+	var fingerprint string
+	var err error
+	if execution.CurrentStage > 1 {
+		fingerprint, err = providerwrite.Fingerprint("provider-repost-v1", struct {
+			Request platform.RepostRequest `json:"request"`
+			Stage   int                    `json:"stage"`
+		}{Request: request, Stage: execution.CurrentStage})
+	} else {
+		fingerprint, err = providerwrite.Fingerprint("provider-repost-v1", request)
+	}
 	if err != nil {
 		return platform.PublishResult{}, err
 	}
+	operationID := "repost:" + execution.ID
+	if execution.CurrentStage > 1 {
+		operationID = fmt.Sprintf("repost:%s:stage:%d", execution.ID, execution.CurrentStage)
+	}
 	jobExecution, _ := providerwrite.JobExecutionFromContext(ctx)
 	return providerwrite.New(s.db).Execute(ctx, providerwrite.Input{
-		OperationID: "repost:" + execution.ID,
+		OperationID: operationID,
 		JobID:       jobExecution.ID, WorkspaceID: execution.WorkspaceID,
 		SocialAccountID: target.ID, TargetKey: repostProviderKey(target),
 		Provider: target.Platform, Operation: "repost", PayloadFingerprint: fingerprint,
@@ -482,8 +630,9 @@ func (s *Service) executionUnavailableReason(ctx context.Context, execution mode
 
 func (s *Service) rescheduleEvaluation(ctx context.Context, execution *models.RepostExecution, runAt time.Time) error {
 	execution.NextCheckAt = runAt
+	execution.StageStatus = StatusPending
 	execution.UpdatedAt = time.Now().UTC()
-	if _, err := s.db.NewUpdate().Model(execution).Column("next_check_at", "updated_at").Where("id = ? AND status = ?", execution.ID, StatusPending).Exec(ctx); err != nil {
+	if _, err := s.db.NewUpdate().Model(execution).Column("next_check_at", "stage_status", "updated_at").Where("id = ? AND status = ?", execution.ID, StatusPending).Exec(ctx); err != nil {
 		return err
 	}
 	return s.enqueueExecution(ctx, execution.ID, JobTypeEvaluate, runAt)
@@ -491,8 +640,9 @@ func (s *Service) rescheduleEvaluation(ctx context.Context, execution *models.Re
 
 func (s *Service) rescheduleEvaluationWithMetrics(ctx context.Context, execution *models.RepostExecution, runAt time.Time) error {
 	execution.NextCheckAt = runAt
+	execution.StageStatus = StatusPending
 	if _, err := s.db.NewUpdate().Model(execution).
-		Column("next_check_at", "check_count", "last_metrics_json", "updated_at").
+		Column("next_check_at", "stage_status", "check_count", "last_metrics_json", "updated_at").
 		Where("id = ? AND status = ?", execution.ID, StatusPending).Exec(ctx); err != nil {
 		return err
 	}
@@ -502,13 +652,14 @@ func (s *Service) rescheduleEvaluationWithMetrics(ctx context.Context, execution
 func (s *Service) finishExecution(ctx context.Context, execution *models.RepostExecution, code, message string) error {
 	now := time.Now().UTC()
 	execution.Status = StatusSkipped
+	execution.StageStatus = StatusSkipped
 	execution.ErrorCode = code
 	execution.ErrorMessage = message
 	execution.NextCheckAt = time.Time{}
 	execution.CompletedAt = now
 	execution.UpdatedAt = now
 	if _, err := s.db.NewUpdate().Model(execution).
-		Column("status", "error_code", "error_message", "next_check_at", "check_count", "last_metrics_json", "completed_at", "updated_at").
+		Column("status", "stage_status", "error_code", "error_message", "next_check_at", "check_count", "last_metrics_json", "completed_at", "updated_at").
 		Where("id = ?", execution.ID).Exec(ctx); err != nil {
 		return err
 	}
@@ -523,13 +674,14 @@ func (s *Service) finishExecution(ctx context.Context, execution *models.RepostE
 func (s *Service) markExecutionFailed(ctx context.Context, execution *models.RepostExecution, code, message string) {
 	now := time.Now().UTC()
 	execution.Status = StatusFailed
+	execution.StageStatus = StatusFailed
 	execution.ErrorCode = code
 	execution.ErrorMessage = message
 	execution.NextCheckAt = time.Time{}
 	execution.CompletedAt = now
 	execution.UpdatedAt = now
 	_, _ = s.db.NewUpdate().Model(execution).
-		Column("status", "error_code", "error_message", "next_check_at", "completed_at", "updated_at").
+		Column("status", "stage_status", "error_code", "error_message", "next_check_at", "completed_at", "updated_at").
 		Where("id = ?", execution.ID).Exec(ctx)
 	s.recordEvent(ctx, *execution, lifecycle.StatusFailed, "repost failed", map[string]any{
 		"target_account_id": execution.TargetAccountID,
@@ -557,6 +709,8 @@ func (s *Service) enqueueExecution(ctx context.Context, executionID, jobType str
 		if err := organizationguard.LockWorkspace(txCtx, tx, workspaceID); err != nil {
 			return err
 		}
+		job.ScopeID = workspaceID
+		job.DedupeKey = fmt.Sprintf("repost:%s:%s", executionID, jobType)
 		_, err := tx.NewInsert().Model(job).On("CONFLICT DO NOTHING").Exec(txCtx)
 		return err
 	})

--- a/backend/internal/services/reposts/service_test.go
+++ b/backend/internal/services/reposts/service_test.go
@@ -3,6 +3,8 @@ package reposts
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -24,12 +26,81 @@ func (testTokenSource) GetValidAccessToken(context.Context, string) (string, err
 
 type testRepostAdapter struct {
 	platform.Adapter
-	requests []platform.RepostRequest
+	requests         []platform.RepostRequest
+	unrepostRequests []platform.UnrepostRequest
 }
 
 func (a *testRepostAdapter) Repost(_ context.Context, _, _ string, request platform.RepostRequest) (platform.RepostResult, error) {
 	a.requests = append(a.requests, request)
-	return platform.RepostResult{ExternalID: "repost-1", ExternalURL: "https://social.example/repost-1"}, nil
+	id := fmt.Sprintf("repost-%d", len(a.requests))
+	return platform.RepostResult{ExternalID: id, ExternalURL: "https://social.example/" + id}, nil
+}
+
+func (a *testRepostAdapter) Unrepost(_ context.Context, _, _ string, request platform.UnrepostRequest) error {
+	a.unrepostRequests = append(a.unrepostRequests, request)
+	return nil
+}
+
+func TestNormalizeRuleMultiStageAndBackwardsCompatibility(t *testing.T) {
+	// Legacy single-stage backwards compatibility
+	legacy := Rule{DelaySeconds: 3600, EvaluationWindowSeconds: 7200, ThresholdMode: ThresholdAll, MinLikes: 10}
+	normalized, err := NormalizeRule(legacy)
+	require.NoError(t, err)
+	require.Equal(t, 3600, normalized.DelaySeconds)
+	require.Len(t, normalized.Stages, 1)
+	require.Equal(t, 1, normalized.Stages[0].Stage)
+	require.Equal(t, 3600, normalized.Stages[0].DelaySeconds)
+	require.False(t, normalized.Stages[0].UnrepostPrevious)
+
+	// Valid multi-stage rule
+	multi := Rule{
+		EvaluationWindowSeconds: 86400,
+		Stages: []RepostStage{
+			{DelaySeconds: 3600, UnrepostPrevious: true}, // UnrepostPrevious on stage 1 should be forced false
+			{DelaySeconds: 7200, UnrepostPrevious: true},
+			{DelaySeconds: 14400, UnrepostPrevious: false},
+		},
+	}
+	normalizedMulti, err := NormalizeRule(multi)
+	require.NoError(t, err)
+	require.Equal(t, 3600, normalizedMulti.DelaySeconds)
+	require.Len(t, normalizedMulti.Stages, 3)
+	require.Equal(t, 1, normalizedMulti.Stages[0].Stage)
+	require.False(t, normalizedMulti.Stages[0].UnrepostPrevious)
+	require.Equal(t, 2, normalizedMulti.Stages[1].Stage)
+	require.True(t, normalizedMulti.Stages[1].UnrepostPrevious)
+	require.Equal(t, 3, normalizedMulti.Stages[2].Stage)
+	require.False(t, normalizedMulti.Stages[2].UnrepostPrevious)
+
+	// Non-increasing delays should fail
+	invalidNonIncreasing := Rule{
+		Stages: []RepostStage{
+			{DelaySeconds: 7200},
+			{DelaySeconds: 7200},
+		},
+	}
+	_, err = NormalizeRule(invalidNonIncreasing)
+	require.ErrorContains(t, err, "monotonically increasing")
+
+	invalidDecreasing := Rule{
+		Stages: []RepostStage{
+			{DelaySeconds: 7200},
+			{DelaySeconds: 3600},
+		},
+	}
+	_, err = NormalizeRule(invalidDecreasing)
+	require.ErrorContains(t, err, "monotonically increasing")
+
+	// Window shorter than last stage delay should fail
+	invalidWindow := Rule{
+		EvaluationWindowSeconds: 5000,
+		Stages: []RepostStage{
+			{DelaySeconds: 3600},
+			{DelaySeconds: 7200},
+		},
+	}
+	_, err = NormalizeRule(invalidWindow)
+	require.ErrorContains(t, err, "evaluation window cannot end before its delay")
 }
 
 func TestThresholdsTreatMissingMetricsAsUnknown(t *testing.T) {
@@ -104,11 +175,14 @@ func TestCustomOverrideSchedulesEvaluatesAndExecutes(t *testing.T) {
 	var execution models.RepostExecution
 	require.NoError(t, db.NewSelect().Model(&execution).Where("rendition_id = ?", rendition.ID).Scan(ctx))
 	require.Equal(t, StatusPending, execution.Status)
+	require.Equal(t, 1, execution.CurrentStage)
+	require.Equal(t, 1, execution.TotalStages)
 	require.NoError(t, service.evaluate(ctx, execution.ID))
 	require.NoError(t, service.execute(ctx, execution.ID))
 	require.NoError(t, db.NewSelect().Model(&execution).Where("id = ?", execution.ID).Scan(ctx))
 	require.Equal(t, StatusSucceeded, execution.Status)
 	require.Equal(t, "repost-1", execution.ExternalID)
+	require.Equal(t, "repost-1", execution.LastRepostExternalID)
 	require.Len(t, adapter.requests, 1)
 	require.Equal(t, "post-1", adapter.requests[0].ExternalID)
 	_, err = db.NewUpdate().Model((*models.RepostExecution)(nil)).
@@ -123,6 +197,198 @@ func TestCustomOverrideSchedulesEvaluatesAndExecutes(t *testing.T) {
 		Where("workspace_id = ? AND metric = ?", workspace.ID, "provider_write_calls_monthly").
 		Scan(ctx))
 	require.Equal(t, int64(1), usage.Value)
+}
+
+func TestMultiStageRepostExecutionWithUnrepost(t *testing.T) {
+	db := repostTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Add(-time.Hour)
+	workspace := models.Workspace{ID: "workspace-1", OrganizationID: "organization-1", Name: "Launch"}
+	user := models.User{ID: "user-1", Email: "user@example.com"}
+	require.NoError(t, insertModels(ctx, db, &workspace, &user, &models.WorkspaceMember{WorkspaceID: workspace.ID, UserID: user.ID, Role: models.WorkspaceRoleAdmin}))
+	source := models.SocialAccount{ID: "source", WorkspaceID: workspace.ID, Slug: "source", Platform: "x", AccountID: "source-provider", AccountUsername: "source", AccessTokenEnc: []byte("token"), IsActive: true}
+	target := models.SocialAccount{ID: "target", WorkspaceID: workspace.ID, Slug: "target", Platform: "x", AccountID: "target-provider", AccountUsername: "target", AccessTokenEnc: []byte("token"), IsActive: true}
+	require.NoError(t, insertModels(ctx, db, &source, &target))
+
+	overrideJSON, err := EncodeOverride(Override{
+		Mode: ModeCustom, TargetAccountIDs: []string{target.ID},
+		Rule: Rule{
+			EvaluationWindowSeconds: 86400,
+			ThresholdMode:           ThresholdAll,
+			MinLikes:                5,
+			PlateauChecks:           2,
+			Stages: []RepostStage{
+				{DelaySeconds: 0, UnrepostPrevious: false},
+				{DelaySeconds: 3600, UnrepostPrevious: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+	publication := models.Publication{
+		ID: "publication-1", WorkspaceID: workspace.ID, CreatedByID: user.ID, Title: "MultiStage Launch", Intent: models.PublishingIntentPost,
+		ContentProfile: models.ContentProfileShortText, SourceText: "Launch", SourceContent: "Launch", Status: models.PublicationStatusPublished,
+		RepostOverride: overrideJSON, ActualRunAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	rendition := models.Rendition{
+		ID: "rendition-1", PublicationID: publication.ID, SocialAccountID: source.ID, Platform: "x", Profile: models.ContentProfileShortText,
+		Status: models.RenditionStatusPublished, ExternalID: "post-source-1", ExternalURL: "https://x.com/source/status/post-source-1", CreatedAt: now, UpdatedAt: now,
+	}
+	require.NoError(t, insertModels(ctx, db, &publication, &rendition))
+	state := models.AnalyticsSyncState{
+		ID: "rendition:" + rendition.ID, WorkspaceID: workspace.ID, SubjectType: "rendition", SubjectID: rendition.ID,
+		SocialAccountID: source.ID, Platform: "x", Status: string(platform.AnalyticsStatusOK), MetricsJSON: `{"likes":10}`,
+		LastSuccessAt: time.Now().UTC(), CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, insertModels(ctx, db, &state))
+
+	adapter := &testRepostAdapter{}
+	service := NewService(db, testTokenSource{})
+	service.SetProvider("x", adapter)
+
+	// Step 1: Schedule
+	require.NoError(t, service.ScheduleForRendition(ctx, rendition.ID))
+
+	var execution models.RepostExecution
+	require.NoError(t, db.NewSelect().Model(&execution).Where("rendition_id = ?", rendition.ID).Scan(ctx))
+	require.Equal(t, StatusPending, execution.Status)
+	require.Equal(t, 1, execution.CurrentStage)
+	require.Equal(t, 2, execution.TotalStages)
+
+	// Step 2: Evaluate Stage 1 -> StatusReady
+	require.NoError(t, service.evaluate(ctx, execution.ID))
+	require.NoError(t, db.NewSelect().Model(&execution).Where("id = ?", execution.ID).Scan(ctx))
+	require.Equal(t, StatusReady, execution.Status)
+
+	// Step 3: Execute Stage 1
+	require.NoError(t, service.execute(ctx, execution.ID))
+	require.NoError(t, db.NewSelect().Model(&execution).Where("id = ?", execution.ID).Scan(ctx))
+	// After stage 1, execution advances to stage 2 and returns to pending status
+	require.Equal(t, StatusPending, execution.Status)
+	require.Equal(t, 2, execution.CurrentStage)
+	require.Equal(t, "repost-1", execution.LastRepostExternalID)
+	require.Len(t, adapter.requests, 1)
+	require.Len(t, adapter.unrepostRequests, 0, "stage 1 should not un-repost")
+
+	// Step 4: Evaluate Stage 2 -> StatusReady
+	require.NoError(t, service.evaluate(ctx, execution.ID))
+	require.NoError(t, db.NewSelect().Model(&execution).Where("id = ?", execution.ID).Scan(ctx))
+	require.Equal(t, StatusReady, execution.Status)
+
+	// Step 5: Execute Stage 2 (UnrepostPrevious: true)
+	require.NoError(t, service.execute(ctx, execution.ID))
+	require.NoError(t, db.NewSelect().Model(&execution).Where("id = ?", execution.ID).Scan(ctx))
+	require.Equal(t, StatusSucceeded, execution.Status)
+	require.Equal(t, 2, execution.CurrentStage)
+	require.Equal(t, "repost-2", execution.LastRepostExternalID)
+	require.Equal(t, "repost-2", execution.ExternalID)
+	require.False(t, execution.CompletedAt.IsZero())
+
+	// Verify adapter received unrepost request for stage 1's repost ID
+	require.Len(t, adapter.unrepostRequests, 1)
+	require.Equal(t, "repost-1", adapter.unrepostRequests[0].RepostExternalID)
+	require.Equal(t, "post-source-1", adapter.unrepostRequests[0].SourceExternalID)
+
+	// Verify adapter received 2 total repost calls
+	require.Len(t, adapter.requests, 2)
+
+	// Verify stage history JSON
+	require.NotEmpty(t, execution.StageHistoryJSON)
+	require.Contains(t, execution.StageHistoryJSON, `"stage":1`)
+	require.Contains(t, execution.StageHistoryJSON, `"stage":2`)
+	require.Contains(t, execution.StageHistoryJSON, `"repost_external_id":"repost-1"`)
+	require.Contains(t, execution.StageHistoryJSON, `"repost_external_id":"repost-2"`)
+
+	var history []StageHistoryEntry
+	require.NoError(t, json.Unmarshal([]byte(execution.StageHistoryJSON), &history))
+	require.Len(t, history, 2)
+	require.False(t, history[0].UnrepostedAt.IsZero(), "stage 1 history entry should have UnrepostedAt populated after stage 2 unrepost")
+	require.True(t, history[1].UnrepostedAt.IsZero(), "stage 2 history entry should not have UnrepostedAt")
+}
+
+type errorUnrepostAdapter struct {
+	platform.Adapter
+	repostCount int
+	unrepostErr error
+}
+
+func (a *errorUnrepostAdapter) Repost(_ context.Context, _, _ string, request platform.RepostRequest) (platform.RepostResult, error) {
+	a.repostCount++
+	id := fmt.Sprintf("repost-%d", a.repostCount)
+	return platform.RepostResult{ExternalID: id, ExternalURL: "https://social.example/" + id}, nil
+}
+
+func (a *errorUnrepostAdapter) Unrepost(_ context.Context, _, _ string, _ platform.UnrepostRequest) error {
+	if a.unrepostErr != nil {
+		return a.unrepostErr
+	}
+	return nil
+}
+
+func TestMultiStageUnrepostTransientErrorBackoff(t *testing.T) {
+	db := repostTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Add(-time.Hour)
+	workspace := models.Workspace{ID: "workspace-1", OrganizationID: "organization-1", Name: "Launch"}
+	user := models.User{ID: "user-1", Email: "user@example.com"}
+	require.NoError(t, insertModels(ctx, db, &workspace, &user, &models.WorkspaceMember{WorkspaceID: workspace.ID, UserID: user.ID, Role: models.WorkspaceRoleAdmin}))
+	source := models.SocialAccount{ID: "source", WorkspaceID: workspace.ID, Slug: "source", Platform: "x", AccountID: "source-provider", AccountUsername: "source", AccessTokenEnc: []byte("token"), IsActive: true}
+	target := models.SocialAccount{ID: "target", WorkspaceID: workspace.ID, Slug: "target", Platform: "x", AccountID: "target-provider", AccountUsername: "target", AccessTokenEnc: []byte("token"), IsActive: true}
+	require.NoError(t, insertModels(ctx, db, &source, &target))
+
+	overrideJSON, err := EncodeOverride(Override{
+		Mode: ModeCustom, TargetAccountIDs: []string{target.ID},
+		Rule: Rule{
+			EvaluationWindowSeconds: 86400,
+			ThresholdMode:           ThresholdAll,
+			MinLikes:                5,
+			PlateauChecks:           2,
+			Stages: []RepostStage{
+				{DelaySeconds: 0, UnrepostPrevious: false},
+				{DelaySeconds: 3600, UnrepostPrevious: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+	publication := models.Publication{
+		ID: "publication-1", WorkspaceID: workspace.ID, CreatedByID: user.ID, Title: "MultiStage Backoff", Intent: models.PublishingIntentPost,
+		ContentProfile: models.ContentProfileShortText, SourceText: "Launch", SourceContent: "Launch", Status: models.PublicationStatusPublished,
+		RepostOverride: overrideJSON, ActualRunAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	rendition := models.Rendition{
+		ID: "rendition-1", PublicationID: publication.ID, SocialAccountID: source.ID, Platform: "x", Profile: models.ContentProfileShortText,
+		Status: models.RenditionStatusPublished, ExternalID: "post-source-1", ExternalURL: "https://x.com/source/status/post-source-1", CreatedAt: now, UpdatedAt: now,
+	}
+	require.NoError(t, insertModels(ctx, db, &publication, &rendition))
+	state := models.AnalyticsSyncState{
+		ID: "rendition:" + rendition.ID, WorkspaceID: workspace.ID, SubjectType: "rendition", SubjectID: rendition.ID,
+		SocialAccountID: source.ID, Platform: "x", Status: string(platform.AnalyticsStatusOK), MetricsJSON: `{"likes":10}`,
+		LastSuccessAt: time.Now().UTC(), CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, insertModels(ctx, db, &state))
+
+	adapter := &errorUnrepostAdapter{}
+	service := NewService(db, testTokenSource{})
+	service.SetProvider("x", adapter)
+
+	require.NoError(t, service.ScheduleForRendition(ctx, rendition.ID))
+	var execution models.RepostExecution
+	require.NoError(t, db.NewSelect().Model(&execution).Where("rendition_id = ?", rendition.ID).Scan(ctx))
+	require.NoError(t, service.evaluate(ctx, execution.ID))
+	require.NoError(t, service.execute(ctx, execution.ID))
+
+	// Now Stage 2 is pending. Advance to Ready.
+	require.NoError(t, service.evaluate(ctx, execution.ID))
+
+	// Set unrepost failure (e.g. transient network error)
+	adapter.unrepostErr = errors.New("temporary upstream network timeout")
+	err = service.execute(ctx, execution.ID)
+	require.Error(t, err)
+
+	// Verify execution is rescheduled with pending status and ~5 min backoff, NOT permanently failed
+	require.NoError(t, db.NewSelect().Model(&execution).Where("id = ?", execution.ID).Scan(ctx))
+	require.Equal(t, StatusPending, execution.Status)
+	require.Equal(t, StatusPending, execution.StageStatus)
+	require.True(t, execution.NextCheckAt.After(time.Now().UTC().Add(4*time.Minute)))
 }
 
 func TestCrossWorkspaceOverrideRequiresGrant(t *testing.T) {

--- a/backend/internal/services/reposts/settings.go
+++ b/backend/internal/services/reposts/settings.go
@@ -668,6 +668,7 @@ func ensureGrantTx(ctx context.Context, tx bun.Tx, workspaceID string, account m
 }
 
 func policyModel(input PolicyInput, workspaceID, userID string, now time.Time) *models.RepostPolicy {
+	stagesJSON, _ := json.Marshal(input.Rule.Stages)
 	return &models.RepostPolicy{
 		ID:                      input.ID,
 		WorkspaceID:             workspaceID,
@@ -682,6 +683,7 @@ func policyModel(input PolicyInput, workspaceID, userID string, now time.Time) *
 		MinViews:                input.Rule.MinViews,
 		RequirePlateau:          input.Rule.RequirePlateau,
 		PlateauChecks:           input.Rule.PlateauChecks,
+		StagesJSON:              string(stagesJSON),
 		CreatedByID:             userID,
 		UpdatedByID:             userID,
 		CreatedAt:               now,
@@ -690,7 +692,11 @@ func policyModel(input PolicyInput, workspaceID, userID string, now time.Time) *
 }
 
 func ruleFromPolicy(policy models.RepostPolicy) Rule {
-	return Rule{
+	var stages []RepostStage
+	if policy.StagesJSON != "" && policy.StagesJSON != "[]" && policy.StagesJSON != "{}" {
+		_ = json.Unmarshal([]byte(policy.StagesJSON), &stages)
+	}
+	rule := Rule{
 		DelaySeconds:            policy.DelaySeconds,
 		EvaluationWindowSeconds: policy.EvaluationWindowSeconds,
 		ThresholdMode:           policy.ThresholdMode,
@@ -700,7 +706,13 @@ func ruleFromPolicy(policy models.RepostPolicy) Rule {
 		MinViews:                policy.MinViews,
 		RequirePlateau:          policy.RequirePlateau,
 		PlateauChecks:           policy.PlateauChecks,
+		Stages:                  stages,
 	}
+	normalized, err := NormalizeRule(rule)
+	if err != nil {
+		return rule
+	}
+	return normalized
 }
 
 func (s *Service) repostAdapter(account models.SocialAccount) platform.RepostAdapter {

--- a/backend/internal/services/reposts/types.go
+++ b/backend/internal/services/reposts/types.go
@@ -48,16 +48,33 @@ func invalidInputf(format string, args ...any) error {
 	return fmt.Errorf("%w: %s", ErrInvalidInput, fmt.Sprintf(format, args...))
 }
 
+type RepostStage struct {
+	Stage            int  `json:"stage,omitempty" doc:"Stage sequence number (1-based)"`
+	DelaySeconds     int  `json:"delay_seconds" minimum:"0" maximum:"2592000" doc:"Delay in seconds after publishing"`
+	UnrepostPrevious bool `json:"unrepost_previous" doc:"Whether to delete the previous stage repost before executing this stage"`
+}
+
+type StageHistoryEntry struct {
+	Stage            int       `json:"stage"`
+	DelaySeconds     int       `json:"delay_seconds"`
+	UnrepostPrevious bool      `json:"unrepost_previous"`
+	RepostExternalID string    `json:"repost_external_id,omitempty"`
+	ExternalURL      string    `json:"external_url,omitempty"`
+	ExecutedAt       time.Time `json:"executed_at"`
+	UnrepostedAt     time.Time `json:"unreposted_at,omitempty"`
+}
+
 type Rule struct {
-	DelaySeconds            int    `json:"delay_seconds" minimum:"0" maximum:"2592000" doc:"Wait after publishing before the first eligibility check"`
-	EvaluationWindowSeconds int    `json:"evaluation_window_seconds" minimum:"900" maximum:"2592000" doc:"How long OpenPost may wait for engagement gates"`
-	ThresholdMode           string `json:"threshold_mode" enum:"all,any" doc:"Require all configured thresholds or any one"`
-	MinLikes                int64  `json:"min_likes" minimum:"0" doc:"Minimum likes; zero disables this gate"`
-	MinComments             int64  `json:"min_comments" minimum:"0" doc:"Minimum comments; zero disables this gate"`
-	MinReposts              int64  `json:"min_reposts" minimum:"0" doc:"Minimum reposts or shares; zero disables this gate"`
-	MinViews                int64  `json:"min_views" minimum:"0" doc:"Minimum views; zero disables this gate"`
-	RequirePlateau          bool   `json:"require_plateau" doc:"Wait until stored engagement has stopped changing"`
-	PlateauChecks           int    `json:"plateau_checks" minimum:"2" maximum:"12" doc:"Consecutive unchanged analytics checks required"`
+	DelaySeconds            int           `json:"delay_seconds" minimum:"0" maximum:"2592000" doc:"Wait after publishing before the first eligibility check"`
+	EvaluationWindowSeconds int           `json:"evaluation_window_seconds" minimum:"900" maximum:"2592000" doc:"How long OpenPost may wait for engagement gates"`
+	ThresholdMode           string        `json:"threshold_mode" enum:"all,any" doc:"Require all configured thresholds or any one"`
+	MinLikes                int64         `json:"min_likes" minimum:"0" doc:"Minimum likes; zero disables this gate"`
+	MinComments             int64         `json:"min_comments" minimum:"0" doc:"Minimum comments; zero disables this gate"`
+	MinReposts              int64         `json:"min_reposts" minimum:"0" doc:"Minimum reposts or shares; zero disables this gate"`
+	MinViews                int64         `json:"min_views" minimum:"0" doc:"Minimum views; zero disables this gate"`
+	RequirePlateau          bool          `json:"require_plateau" doc:"Wait until stored engagement has stopped changing"`
+	PlateauChecks           int           `json:"plateau_checks" minimum:"2" maximum:"12" doc:"Consecutive unchanged analytics checks required"`
+	Stages                  []RepostStage `json:"stages,omitempty" doc:"Optional multi-stage repost sequence"`
 }
 
 type Override struct {
@@ -157,14 +174,44 @@ func NormalizeRule(rule Rule) (Rule, error) {
 	if rule.PlateauChecks == 0 {
 		rule.PlateauChecks = 2
 	}
-	if rule.DelaySeconds < 0 || time.Duration(rule.DelaySeconds)*time.Second > maxDelay {
-		return Rule{}, invalidInputf("repost delay must be between 0 and 30 days")
+	if len(rule.Stages) == 0 {
+		if rule.DelaySeconds < 0 || time.Duration(rule.DelaySeconds)*time.Second > maxDelay {
+			return Rule{}, invalidInputf("repost delay must be between 0 and 30 days")
+		}
+		rule.Stages = []RepostStage{{
+			Stage:            1,
+			DelaySeconds:     rule.DelaySeconds,
+			UnrepostPrevious: false,
+		}}
+	} else {
+		if len(rule.Stages) > 20 {
+			return Rule{}, invalidInputf("repost rules support at most 20 stages")
+		}
+		for i := range rule.Stages {
+			stage := &rule.Stages[i]
+			stage.Stage = i + 1
+			if i == 0 {
+				stage.UnrepostPrevious = false
+				if stage.DelaySeconds < 0 || time.Duration(stage.DelaySeconds)*time.Second > maxDelay {
+					return Rule{}, invalidInputf("repost stage 1 delay must be between 0 and 30 days")
+				}
+			} else {
+				if stage.DelaySeconds <= rule.Stages[i-1].DelaySeconds {
+					return Rule{}, invalidInputf("multi-stage repost delays must be monotonically increasing")
+				}
+				if time.Duration(stage.DelaySeconds)*time.Second > maxDelay {
+					return Rule{}, invalidInputf("repost stage %d delay must be between 0 and 30 days", stage.Stage)
+				}
+			}
+		}
+		rule.DelaySeconds = rule.Stages[0].DelaySeconds
 	}
+	lastDelay := rule.Stages[len(rule.Stages)-1].DelaySeconds
 	window := time.Duration(rule.EvaluationWindowSeconds) * time.Second
 	if window < 15*time.Minute || window > maxEvaluationWindow {
 		return Rule{}, invalidInputf("repost evaluation window must be between 15 minutes and 30 days")
 	}
-	if rule.EvaluationWindowSeconds < rule.DelaySeconds {
+	if rule.EvaluationWindowSeconds < lastDelay {
 		return Rule{}, invalidInputf("repost evaluation window cannot end before its delay")
 	}
 	if rule.ThresholdMode != ThresholdAll && rule.ThresholdMode != ThresholdAny {

--- a/changes/bluesky-mention-resolution.md
+++ b/changes/bluesky-mention-resolution.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed Bluesky handle resolution for multi-segment handles by ensuring the full domain handle is extracted from mentions instead of submatch fragments.

--- a/changes/growth-discovery-sqlite-deadlock.md
+++ b/changes/growth-discovery-sqlite-deadlock.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Prevented growth discovery jobs from deadlocking on SQLite single-connection deployments when initializing sync state for newly connected social accounts.

--- a/changes/repost-multi-stage-cycles.md
+++ b/changes/repost-multi-stage-cycles.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added multi-stage repost cycles with un-repost support across X, Bluesky, Mastodon, and LinkedIn adapters, enabling automated recurring resharing workflows with previous cycle un-reposting and stage history tracking.


### PR DESCRIPTION
## Description

This PR introduces two improvements:

1. **Multi-Stage Repost Cycles with Un-Repost Support**:
   - Supports multi-stage scheduled repost/retweet cycles across X, Bluesky, Mastodon, and LinkedIn adapters.
   - Adds database migration for stage history tracking and un-reposting of prior cycle reposts.

2. **Fix Bluesky Multi-Segment Handle Resolution**:
   - Fixes `@blueskyMentionPattern` and `resolveBlueskyComposerReferences` in `internal/platform/bluesky.go`.
   - Previously, submatch indexing captured only domain fragments (e.g. `bsky.`) when resolving handles like `@mercurykitsune.bsky.social`, causing 400 Bad Request rejections on ATProto handle resolution.
   - Captures the complete domain handle and adds unit tests covering multi-segment handle resolution and UTF-8 byte facet calculations with emojis.

## Testing
- Unit tests added in `backend/internal/platform/bluesky_test.go` and `backend/internal/services/reposts/service_test.go`.
- All backend tests passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added multi-stage repost cycles with configurable delays, stage history, and recurring resharing.
  - Added unrepost support across X, Bluesky, Mastodon, and LinkedIn.
  - Previous repost stages can be removed automatically, with retry handling for temporary failures.

- **Bug Fixes**
  - Improved Bluesky mention resolution for multi-segment handles and duplicate matches.
  - Prevented growth discovery deadlocks on single-connection SQLite deployments.

- **Tests**
  - Expanded coverage for staged reposting, unreposting, recovery, and platform-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->